### PR TITLE
Adds CLI reference and Metrics guide.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -82,7 +82,14 @@ module.exports = {
           {
             title: 'Operators',
             path: '/operators/',
-            children: ['/operators/deploy']
+            children: [
+              '/operators/deploy',
+              '/operators/metrics',
+              '/operators/drand-cli',           ]
+          },
+          {
+            title: 'Builders',
+            path: '/builders/'
           },
           {
             title: 'Project',

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -85,7 +85,8 @@ module.exports = {
             children: [
               '/operators/deploy',
               '/operators/metrics',
-              '/operators/drand-cli',           ]
+              '/operators/drand-cli'
+            ]
           },
           {
             title: 'Builders',

--- a/docs/builders/README.md
+++ b/docs/builders/README.md
@@ -1,0 +1,31 @@
+---
+title: 'Builders'
+---
+
+# Builder's Guide
+
+This section helps you build applications that use Drand as a source of randomness. For help running a Drand network, see the [Operator's Guide](../operators/).
+
+There are several ways to consume randomness from a Drand network:
+
+- [Using the `drand` binary](#using-the-drand-command-to-fetch-randomness)
+- [Fetching randomness over HTTP](#fetching-randomness-over-http)
+- [Receiving randomness using libp2p PubSub](#receiving-randomness-using-libp2p-pubsub)
+- [Using a Drand client library](#using-a-drand-client-library)
+
+
+## Using the `drand` command to fetch randomness
+
+The `drand` command can be used to fetch randomness from a running Drand network. To do so, you'll need the group configuration file,
+
+## Fetching randomness over HTTP
+
+TK
+
+## Receiving randomness using libp2p PubSub
+
+TK
+
+## Using a Drand client library
+
+### drand.js

--- a/docs/builders/README.md
+++ b/docs/builders/README.md
@@ -8,24 +8,41 @@ This section helps you build applications that use Drand as a source of randomne
 
 There are several ways to consume randomness from a Drand network:
 
-- [Using the `drand` binary](#using-the-drand-command-to-fetch-randomness)
 - [Fetching randomness over HTTP](#fetching-randomness-over-http)
-- [Receiving randomness using libp2p PubSub](#receiving-randomness-using-libp2p-pubsub)
 - [Using a Drand client library](#using-a-drand-client-library)
+- [Using the `drand` binary](#using-the-drand-command-to-fetch-randomness)
 
+## Fetching randomness over HTTP
+
+Drand provides an HTTP interface that clients can use to fetch randomness from the Drand network.
+
+All that's required is the address of the HTTP interface and way to fetch from HTTP, e.g. `curl`:
+
+```
+curl <address>/public/latest
+```
+
+This will return JSON output similar to the following:
+
+```json
+{
+  "round": 367,
+  "signature": "b62dd642e939191af1f9e15bef0f0b0e9562a5f570a12a231864afe468377e2a6424a92ccfc34ef1471cbd58c37c6b020cf75ce9446d2aa1252a090250b2b1441f8a2a0d22208dcc09332eaa0143c4a508be13de63978dbed273e3b9813130d5",
+  "previous_signature": "afc545efb57f591dbdf833c339b3369f569566a93e49578db46b6586299422483b7a2d595814046e2847494b401650a0050981e716e531b6f4b620909c2bf1476fd82cf788a110becbc77e55746a7cccd47fb171e8ae2eea2a22fcc6a512486d",
+  "randomness": "d7aed3686bf2be657e6d38c20999831308ee6244b68c8825676db580e7e3bec6"
+}
+```
+
+## Using DrandJS
+
+Drand can easily be used from JavaScript using [DrandJS](https://github.com/drand/drandjs). The main `fetchAndVerify` method of this JavaScript
+library fetches from a drand node the latest random beacon generated and then verifies it against the distributed key. For more details on the
+procedure and instructions on how to use it, refer to the readme.
 
 ## Using the `drand` command to fetch randomness
 
 The `drand` command can be used to fetch randomness from a running Drand network. To do so, you'll need the group configuration file,
+which can be obtained from a Drand node operator using the [`drand show group` command](../operators/drand-cli/#drand-show).
 
-## Fetching randomness over HTTP
-
-TK
-
-## Receiving randomness using libp2p PubSub
-
-TK
-
-## Using a Drand client library
-
-### drand.js
+Once you have the group file, the latest randomness can be obtained with `drand get public`. The output will be in the same JSON format
+as when fetching via HTTP. For more information, see the [Command Line Tools section](/operators/drand-cli/#drand-get).

--- a/docs/concepts/what-is-drand/README.md
+++ b/docs/concepts/what-is-drand/README.md
@@ -1,8 +1,8 @@
 ---
-title: What is drand?
+title: What is Drand?
 ---
 
-# What is drand?
+# What is Drand?
 
 ## Overview and Goals
 
@@ -10,15 +10,15 @@ Many of the digital applications we rely on require a secure source of randomnes
 
 However, constructing a secure source of randomness is not a trivial matter, especially if the random values need to be shared with many participants. While most computers are capable of generating randomness locally (using, for example, `/dev/urandom` on UNIX platforms), it's not possible to prove to someone else that the generated value was truly random and not subject to some bias. There are also countless examples of attacks on secured systems that were made possible by weaknesses in random number generation, including the use of algorithms with non-uniform distribution or biased output. Such weaknesses can undermine the foundation of an otherwise secure system and can lead to severe and subtle vulnerabilities.
 
-`drand` aims to address this problem by providing a Randomness-as-a-Service network, similar to the NTP network which provides time-as-a-service, or Certificate Authority servers which provide certificate verification. `drand` provides a continuous source of randomness with these key properties:
+Drand aims to address this problem by providing a Randomness-as-a-Service network, similar to the NTP network which provides time-as-a-service, or Certificate Authority servers which provide certificate verification. Drand provides a continuous source of randomness with these key properties:
 
-- **Decentralized**: a `drand` network is not controlled by any one of its members, which means that there is no single point of failure, and none of the `drand` server operators are able to bias the output.
-- **Publicly verifiable**: `drand` periodically delivers randomness that is publicly verifiable and unbiased. Any third party can fetch and verify the authenticity of the randomness to ensure that it hasn't been tampered with.
-- **Optionally private**: in addition to "public" randomness, `drand` nodes can also deliver "private" encrypted randomness to be used in local applications. This may be used to seed the operating system RNG with an outside source of entropy.
+- **Decentralized**: a Drand network is not controlled by any one of its members, which means that there is no single point of failure, and none of the Drand server operators are able to bias the output.
+- **Publicly verifiable**: Drand periodically delivers randomness that is publicly verifiable and unbiased. Any third party can fetch and verify the authenticity of the randomness to ensure that it hasn't been tampered with.
+- **Optionally private**: in addition to "public" randomness, Drand nodes can also deliver "private" encrypted randomness to be used in local applications. This may be used to seed the operating system RNG with an outside source of entropy.
 
 ## Public Randomness
 
-Generating public randomness is the primary functionality of `drand`. Public randomness is generated collectively by `drand`nodes and made publicly available. The main challenge in generating good randomness is that no party involved in the randomness generation process should be able to predict or bias the final output. Additionally, the final result has to be verifiable by a third-party to make it actually useful for applications like lotteries, sharding, or parameter generation in security protocols.
+Generating public randomness is the primary functionality of Drand. Public randomness is generated collectively by Drand nodes and made publicly available. The main challenge in generating good randomness is that no party involved in the randomness generation process should be able to predict or bias the final output. Additionally, the final result has to be verifiable by a third-party to make it actually useful for applications like lotteries, sharding, or parameter generation in security protocols.
 
 A drand randomness beacon is composed of a distributed set of nodes and has two phases:
 

--- a/docs/operators/deploy.md
+++ b/docs/operators/deploy.md
@@ -1,11 +1,12 @@
 ---
-title: Deploy
+title: Deploying a Drand Network
 description: Learn how to deploy a Drand node onto your network.
+sidebarDepth: 2
 ---
 
-# Deploy a drand node
+# Deploy a Drand Network Node
 
-This document explains in details the workflow to have a working group of drand
+This document explains in detail the workflow to have a working group of drand
 nodes generate randomness. On a high-level, the workflow looks like this:
 
 - **Setup**: generation of individual long-term key pair and the group file and
@@ -27,6 +28,8 @@ The setup process for a drand node consists of the following steps:
 This document explains how to do the setup with the drand binary itself. drand also offers
 a docker image to run the setup. You can find the information for running with docker
 [here](https://github.com/drand/drand/blob/master/docker/README.md).
+
+If you have not already installed `drand`, please see the [installation guide](./drand-cli/#installing-drand)
 
 ### Long-Term Key
 

--- a/docs/operators/drand-cli.md
+++ b/docs/operators/drand-cli.md
@@ -1,0 +1,305 @@
+---
+title: Drand Command Line Tools
+sidebarDepth: 2
+---
+
+# Drand Command Line Tools
+
+Drand's main functionality is provided by the `drand` program, which allows you to run a Drand server and control its operation. You can also
+use `drand` as a client to fetch randomness from a Drand network.
+
+See the [Supplemental Tools](#supplemental-tools) for some other helpful tools for scaling Drand, as well as a standalone client for consuming
+randomness.
+
+## Installing `drand`
+
+### Binary Releases
+
+The simplest way to get `drand` is to [download a pre-built binary release](https://github.com/drand/drand/releases) for your platform.
+
+You can verify the checksum of a `drand` binary release by checking the `checksums.txt` listed in the GitHub assets for the release, which
+contains the SHA-256 checsum for each release archive. To check your local download, you can use the `shasum` command:
+
+```
+shasum -a 256 <path-to-drand.tar.gz>
+```
+
+### Source Code
+
+You can compile `drand` from source code by cloning the [drand GitHub repository](https://github.com/drand/drand) and building the project.
+
+This will require a working [Golang installation](https://golang.org/doc/install), and your
+[GOPATH](https://golang.org/doc/code.html#GOPATH) must be set. You'll also need the `make` command available.
+
+With those requirements met, install drand via:
+
+```bash
+git clone https://github.com/drand/drand
+cd drand
+make install
+```
+
+This will install `drand` into `$GOPATH/bin`, which should be on your `$PATH` if you followed the standard Go install instructions.
+
+If you'd prefer not to install `drand` globally, or if you want to put the `drand` binary in a different location, you can run `make build` instead
+of `make install`. This will create the `drand` binary in the current directory.
+
+## Usage
+
+This section gives a basic overview of the main `drand` CLI interface to give an idea of the options available.
+If you're setting up a Drand network deployment, please see the [Deployment Guide](./deploy.md), which walks through
+using `drand` to run a live network.
+
+The `drand` command has several subcommands. Among the most important is `drand help`, which will introduce you to
+the rest of the subcommands:
+
+```
+$ drand help
+
+NAME:
+   drand - distributed randomness service
+
+USAGE:
+   drand [global options] command [command options] [arguments...]
+
+VERSION:
+   0.9.1
+
+COMMANDS:
+   start  Start the drand daemon.
+   stop   Stop the drand daemon.
+
+   share             Launch a sharing protocol.
+   generate-keypair  Generate the longterm keypair (drand.private, drand.public)for this node.
+
+   get  get allows for public information retrieval from a remote drand node.
+
+   util  Multiple commands of utility functions, such as reseting a state, checking the connection of a peer...
+   show  local information retrieval about the node's cryptographic material. Show prints the information about the collective public key (drand.cokey), the group details (group.toml), the long-term private key (drand.private), the long-term public key (drand.public), or the private key share (drand.share), respectively.
+
+   help, h  Shows a list of commands or help for one command
+
+GLOBAL OPTIONS:
+   --verbose       If set, verbosity is at the debug level (default: false)
+   --folder value  Folder to keep all drand cryptographic information, with absolute path. (default: "/home/yusef/.drand")
+   --help, -h      show help (default: false)
+   --version, -v   print the version (default: false)
+```
+
+The `help` command can be used for subcommands as well, for example `drand help generate-keypair`. If you prefer, you can
+also show help with the `--help` flag after the subcommand name, e.g.: `drand generate-keypair --help`.
+
+### `drand generate-keypair`
+
+The `generate-keypair` command creates a long-term public/private keypair for a drand node. It should
+be run before starting the node, and you must provide the address that your Drand
+node will listen on, including the publicly reachable port number. This may be different than the port specified
+when starting the daemon, for example if you've set up `drand` to run behind a reverse proxy as described in
+the [Deployment Guide](./deploy/).
+
+```
+$ drand help generate-keypair
+
+NAME:
+   drand generate-keypair - Generate the longterm keypair (drand.private, drand.public)for this node.
+
+
+USAGE:
+   drand generate-keypair [command options] <address> is the public address for other nodes to contact
+
+OPTIONS:
+   --folder value  Folder to keep all drand cryptographic information, with absolute path. (default: "/home/drand/.drand")
+   --tls-disable   Disable TLS for all communications (not recommended). (default: false)
+```
+
+The generated key and all other drand state will be stored in `$HOME/.drand` by default, but this
+can be overridden with the `--folder` flag.
+
+The `--tls-disable` flag should only be used if intend to run an insecure test deployment without TLS protection.
+If either `drand` itself or a reverse proxy is providing TLS protection, the keypair must be generated with TLS
+set to the default of `true`.
+
+### `drand start`
+
+The `start` command starts the drand daemon. Note that `drand` does not automatically go into the background when launched, and
+long-running deployments should be run inside of a `screen` or `tmux` session, or otherwise "daemonized" using the tools available
+for your operating system.
+
+If this node has already joined a network by performing a Distributed Key Generation
+phase, it will attempt to catch up with the drand beacon chain by contacting other nodes and will participate in the randomness
+generation protocol once it has caught up.
+
+If the DKG has not yet been performed, the daemon will wait for an operator to begin the DKG phase using the
+[`drand share`](#drand-share) command.
+
+```
+$ drand help start
+
+NAME:
+   drand start - Start the drand daemon.
+
+USAGE:
+   drand start [command options] [arguments...]
+
+OPTIONS:
+   --folder value          Folder to keep all drand cryptographic information, with absolute path. (default: "/home/yusef/.drand")
+   --tls-cert value        Set the TLS certificate chain (in PEM format) for this drand node. The certificates have to be specified as a list of whitespace-separated file paths. This parameter is required by default and can only be omitted if the --tls-disable flag is used.
+   --tls-key value         Set the TLS private key (in PEM format) for this drand node. The key has to be specified as a file path. This parameter is required by default and can only be omitted if the --tls-disable flag is used.
+   --tls-disable           Disable TLS for all communications (not recommended). (default: false)
+   --control value         Set the port you want to listen to for control port commands. If not specified, we will use the default port 8888.
+   --private-listen value  Set the listening (binding) address of the private API. Useful if you have some kind of proxy.
+   --public-listen value   Set the listening (binding) address of the public API. Useful if you have some kind of proxy.
+   --metrics value         Launch a metrics server at the specified (host:)port.
+   --certs-dir value       directory containing trusted certificates. Useful for testing and self signed certificates
+   --push                  Push mode forces the daemon to start making beacon requests to the other node, instead of waiting the other nodes contact it to catch-up on the round (default: false)
+   --verbose               If set, verbosity is at the debug level (default: false)
+   --private-rand          Enables the private randomness feature on the daemon. By default, this feature is disabled. (default: false)
+```
+
+#### Endpoint configuration
+
+`drand` exposes up to four endpoints, depending on the flags passed in.
+
+The **private Drand API endpoint** is used to communicate with other nodes using gRPC. The private API is always enabled.
+If no flag is given, `drand` will bind to the address used when [generating the node's keypair](#drand-generate-keypair).
+If you want `drand` to listen on a different interface and/or port, you can pass the `--private-listen` flag and
+specify the `host:port` to bind to. Note that the addresss associated with the keypair must be publicly accessible
+and mapped to the `--private-listen` address, for example using a reverse proxy.
+
+The **control API endpoint** is used by the `drand` command to control a running drand daemon using commands like
+[`drand share`](#drand-share).
+
+The control interface is always enabled and bound to the `localhost` interface. The default port is `8888`, but this can be
+overridden with the `--control` flag. If you use a non-standard control port, you will also need to use the `--control` flag
+when running other commands such as `drand share`.
+
+::: danger
+The control API exposes private information, therefore, **the control port must not be exposed to the internet** and should be used only from the local machine where the `drand` daemon is running.
+:::
+
+The remaining endpoints are optional, and will only be enabled if the flags are given.
+
+The **public HTTP endpoint** provides an API that clients can fetch randomness from. To enable it, pass in the
+`--public-listen` flag and specify the `host:port` that you want to listen on. This endpoint exposes no sensitive
+information and is safe to expose to the internet. Alternatively, you may keep this endpoint behind a firewall and
+expose randomness to the public with the help of a relay server such as [`drand-relay-http`](#drand-relay-http).
+
+Finally, the **metrics endpoint** provides an API for observing runtime metrics about the drand node. It can be enabled
+with the `--metrics <metrics-port>` flag. See [Drand Metrics](./metrics/) for more details on accessing the metrics.
+
+#### TLS Configuration
+
+The `--tls-cert` and `--tls-key` commands give the path to TLS certificates and keys needed for `drand` to provide TLS protection
+to its connections with other `drand` nodes. If you are using a reverse proxy as described in the [Deployment Guide](./deploy/),
+you shoul pass the `--tls-disable` flag, as the proxy will handle TLS instead of `drand`.
+
+::: danger
+The `--tls-disable` flag may also be used to run without TLS entirely, but we **do not recommend** disabling TLS except for local
+testing and `drand` development. If you do run without TLS, you must also provide the `--tls-disable` flag when
+[generating your key](#drand-generate-keypair).
+:::
+
+For more on TLS setup, see the [Deployment Guide](./deploy/).
+
+### `drand stop`
+
+The `stop` command tells the `drand` daemon to shut down.
+
+::: tip
+If the daemon was started with a non-standard control port, you must use the `--control` flag to specify the control port
+when running `drand stop`.
+:::
+
+### `drand share`
+
+The `share` command tells the `drand` daemon to begin the Distributed Key Generation (DKG) protocol to create private key shares
+with the other Drand nodes.
+
+There `share` command must be used when setting up a new Drand network before randomness generation can begin. It may also be
+used after the network is running to "re-share" the key material, which allows us to change the members of the Drand network
+without interrupting the generation of randomness.
+
+For details about to running the initial DKG, see the [Deployment Guide](./deploy/).
+
+```
+NAME:
+   drand share - Launch a sharing protocol.
+
+USAGE:
+   drand share [command options] [arguments...]
+
+OPTIONS:
+   --tls-disable         Disable TLS for all communications (not recommended). (default: false)
+   --control value       Set the port you want to listen to for control port commands. If not specified, we will use the default port 8888.
+   --from value          Old group.toml path to specify when a new node wishes to participate in a resharing protocol. This flag is optional in case a node is alreadyincluded in the current DKG.
+   --timeout value       Timeout to use during the DKG, in string format. Default is 10s
+   --source value        Source flag allows to provide an executable which output will be used as additional entropy during resharing step.
+   --user-source-only    user-source-only flag used with the source flag allows to only use the user's entropy to pick the dkg secret (won't be mixed with crypto/rand). Should be used for reproducibility and debbuging purposes. (default: false)
+   --secret value        Specify the secret to use when doing the share so the leader knows you are an eligible potential participant
+   --period value        period to set when doing a setup
+   --nodes value         number of nodes expected (default: 0)
+   --threshold value     threshold to use for the DKG (default: 0)
+   --connect value       Address of the coordinator that will assemble the public keys and start the DKG
+   --out value           save the group file into a separate file instead of stdout
+   --leader              Specify if this node should act as the leader for setting up the group (default: false)
+   --beacon-delay value  Leader uses this flag to specify the genesis time or transition time as a delay from when group is ready to run the share protocol (default: 0)
+   --transition          When set, this flag indicates the share operation is a resharing. The node will use the currently stored group as the basis for the resharing (default: false)
+```
+
+The node that begins the sharing procedure should run with the `--leader` flag. This other nodes use the `--connect <leader-addr>` flag, passing
+in the address of the leader. All of the nodes must specify the following values:
+
+- `--secret` - a secret value, shared out-of-band with the other node operators. When re-sharing, this may be distinct from
+  the secrets used for any prior DKG rounds.
+- `--period` - sets the interval between rounds of the Drand beacon chain. This must be a string that's parse-able by Golang's
+  [time.ParseDuration function](https://golang.org/pkg/time/#ParseDuration), for example "30s" or "1m".
+- `--nodes` - the number of nodes expected to take part in the DKG. Note that the DKG will succeed even if fewer nodes participate,
+  so long as there are enough to meet the threshold.
+- `--threshold` - the number of nodes required to generate randomness. The DKG will fail if fewer than `threshold` nodes participate
+  in the DKG before the timeout.
+
+Whe re-sharing to nodes that are not members of the existing Drand group, the new nodes must obtain a copy of the group configuration file
+from an existing member, and use the `--from <group-file-path>` command to specify the path to the `group.toml` file. Members of
+the existing group may omit the `--from` flag, as they already posess the group configuration.
+
+::: tip
+You can mix an external source of entropy into the key sharing protocol by using the `--source` flag. The argument should be the path
+to an executable that must output random binary data when run. By default, external entropy sources are mixed with Golang's `crypto/rand` secure RNG. The `--user-source-only` flag overrides this default, which is useful during testing and debugging to allow a reproducible "random" value,
+but should not be used in production.
+:::
+
+### `drand get`
+
+TK
+
+### `drand show`
+
+TK
+
+### `drand util`
+
+TK
+
+## Supplemental Tools
+
+In addition to the main `drand` cli app, there are several supplemental tools that can be used to consume randomness from
+a Drand network or help securely scale a Drand deployment.
+
+The following tools do not yet have binary releases and must be installed from source. The basic procedure is the same
+as [installing drand from source](#source-code), but instead of `make install` or `make build`, you'll run one of:
+
+- `make client`
+- `make relay-http`
+- `make relay-gossip`
+
+### `drand-client`
+
+TK
+
+### `drand-relay-http`
+
+TK
+
+### `drand-relay-gossip`
+
+TK

--- a/docs/operators/drand-cli.md
+++ b/docs/operators/drand-cli.md
@@ -168,7 +168,7 @@ and mapped to the `--private-listen` address, for example using a reverse proxy.
 
 ::: warning
 While the private API is primarily intended for inter-node communication, it may be exposed to the internet to allow clients
-to fetch randomness over gRPC using the [`drand get`](#drand-get) command and/or [`drand-client`](#drand-client). 
+to fetch randomness over gRPC using the [`drand get`](#drand-get) command and/or [`drand-client`](#drand-client).
 This will not allow access to any secret information, but we generally recommend restricting gRPC access using firewall
 rules to limit the potential for denial of service attacks.
 :::
@@ -318,9 +318,9 @@ The `util` command provides several subcommands that are useful for debugging an
   reached before running `drand share`.
 - `drand util ping` sends a ping to the local `drand` daemon and prints its status.
 - `drand util reset` deletes all distributed information (group file, key share, random beacon state, etc) from the local node. It
-does NOT delete the long-term keypair.
+  does NOT delete the long-term keypair.
 - `drand util del-beacon <round-number>` deletes all beacon chain rounds from `<round-number>` until the current head of the beacon
-chain from the local node's database. You MUST restart the daemon after issuing this command.
+  chain from the local node's database. You MUST restart the daemon after issuing this command.
 
 For full usage information, run `drand util --help`.
 
@@ -338,12 +338,27 @@ as [installing drand from source](#source-code), but instead of `make install` o
 
 ### `drand-client`
 
-TK
+The `drand-client` command is a standalone Drand client that's optimized to fetch randomness from a Drand network and provide it over a CDN.
+
+The client is configured with the URL for a Drand HTTP endpoint, and may optionally be configured with the addresses of one or more
+libp2p relay nodes. If libp2p relays are configured, the HTTP endpoint will be used as a fallback if the libp2p relays fail to deliver
+randomness at the expected interval.
+
+To see full usage information, run `drand-client help`.
 
 ### `drand-relay-http`
 
-TK
+The `drand-relay-http` command provides a gRPC to HTTP relay server that can be used to relay requests from the public internet to a Drand
+daemon. This is an alternative to the public HTTP endpoint that runs in the main `drand` process when starting `drand` with the `--public-listen`
+flag.
+
+While the `--public-listen` flag is convenient, running a seperate relay process allows the HTTP communications to be isolated from the
+main `drand` process, which limits the attack surface of the `drand` daemon.
+
+To see full usage information, run `drand-relay-http help`.
 
 ### `drand-relay-gossip`
 
-TK
+The `drand-relay-gossip` command provides a relay server that connects to a Drand node over gRPC and provides randomness to consumers over
+a [libp2p PubSub](https://docs.libp2p.io/concepts/publish-subscribe/) topic. Randomness provided by a gossip relay may be consumed directly
+over PubSub by libp2p-capable programs, and/or via a CDN which has been configured to listen to a PubSub topic using `drand-client`.

--- a/docs/operators/metrics.md
+++ b/docs/operators/metrics.md
@@ -1,0 +1,31 @@
+---
+title: Drand Metrics
+---
+
+# Drand Metrics
+
+Drand uses [prometheus](https://prometheus.io/) instrumentation for helping
+operators monitor and understand the runtime behavior of system.
+
+## Local Metrics
+
+The local drand node exposes metrics on an HTTP server listening as specified
+by the `--metrics` comamnd line flag. You can view the reported metrics
+in a browser at `http://localhost:<metrics port>/metrics`. This page includes
+* The default Golang process metrics collected by prometheus
+* Statistics on the drand beacon and group behavior
+* Statistics on the HTTP public listener request load if enabled.
+
+## Shared Group Metrics
+
+In addition to the metrics collected within the local node, the drand
+GRPC group protocol supports re-export and sharing of group metrics
+between group members. When a local metrics port is specified,
+metrics shared by other group members can be accessed at
+`http://localhost:<metrics port>/peer/<peer address>/metrics`.
+This will only inlclude the drand beacon statistics shared by the
+remote peer, and does not include the process or internal health of
+the node. It is meant to allow better visibility when debugging
+network issues, and helping operators understand where problems
+originate.
+.


### PR DESCRIPTION
This brings in the `METRICS.md` from the drand repo, and also adds a `Command Line Tools` page in the Operators section that covers the main `drand` subcommands.

TODO:

- [x] `drand get`
- [x] `drand show`
- [x] `drand util`
- [x] `drand-client`
- [x] `drand-relay-http`
- [x] `drand-relay-gossip`
- [ ] flesh out Builders page (possibly in a different PR)