### PR TITLE
refactor: change order of navbar items

### DIFF
--- a/docs/.vuepress/theme/components/Navbar.vue
+++ b/docs/.vuepress/theme/components/Navbar.vue
@@ -1,0 +1,102 @@
+<template>
+  <header class="navbar">
+    <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
+
+    <RouterLink :to="$localePath" class="home-link">
+      <img
+        v-if="$site.themeConfig.logo"
+        class="logo"
+        :src="$withBase($site.themeConfig.logo)"
+        :alt="$siteTitle"
+      />
+    </RouterLink>
+
+    <div class="links">
+      <NavLinks class="can-hide" />
+      <AlgoliaSearchBox v-if="isAlgoliaSearch" :options="algolia" />
+      <SearchBox
+        v-else-if="
+          $site.themeConfig.search !== false &&
+          $page.frontmatter.search !== false
+        "
+      />
+    </div>
+  </header>
+</template>
+
+<script>
+import AlgoliaSearchBox from '@AlgoliaSearchBox'
+import SearchBox from '@SearchBox'
+import SidebarButton from '@theme/components/SidebarButton.vue'
+import NavLinks from '@theme/components/NavLinks.vue'
+
+export default {
+  name: 'Navbar',
+
+  components: {
+    SidebarButton,
+    NavLinks,
+    SearchBox,
+    AlgoliaSearchBox
+  },
+
+  computed: {
+    algolia() {
+      return (
+        this.$themeLocaleConfig.algolia || this.$site.themeConfig.algolia || {}
+      )
+    },
+
+    isAlgoliaSearch() {
+      return this.algolia && this.algolia.apiKey && this.algolia.indexName
+    }
+  }
+}
+</script>
+
+<style lang="stylus">
+$navbar-vertical-padding = 0.7rem
+$navbar-horizontal-padding = 1.5rem
+
+.navbar
+  display flex
+  background-color #222
+  border-bottom-color #000
+  padding $navbar-vertical-padding $navbar-horizontal-padding
+  line-height $navbarHeight - 1.4rem
+  a, span, img
+    display inline-block
+  .logo
+    height $navbarHeight - 1.4rem
+    min-width $navbarHeight - 1.4rem
+    margin-right 0.8rem
+    vertical-align top
+  .home-link
+    flex none
+  .links
+    padding-left 1.5rem
+    box-sizing border-box
+    background-color #222
+    white-space nowrap
+    font-size 0.9rem
+    position absolute
+    right $navbar-horizontal-padding
+    top $navbar-vertical-padding
+    display flex
+    .search-box
+      flex 0 0 auto
+      vertical-align top
+
+@media (min-width: $MQMobile)
+  .navbar
+    .links
+      position static
+      flex 1 1 auto
+      justify-content space-between
+
+@media (max-width: $MQMobile)
+  .navbar
+    padding-left 4rem
+    .can-hide
+      display none
+</style>

--- a/docs/.vuepress/theme/styles/header.styl
+++ b/docs/.vuepress/theme/styles/header.styl
@@ -1,14 +1,7 @@
 header.navbar {
-	background: #222;
-	border-bottom-color: #000;
-
 	.sidebar-button {
-		color: white;
 		top: 0.8rem;
-	}
-
-	.links {
-		background: #222;
+		color: white;
 	}
 
 	.nav-item a, .repo-link {
@@ -22,10 +15,6 @@ header.navbar {
 			border-bottom: 0;
 		}
 	}
-}
-
-header.navbar .site-name.can-hide {
-	display: none;
 }
 
 header .search-box {
@@ -57,6 +46,16 @@ header .search-box {
 	}
 }
 
+@media (min-width: $MQMobile) {
+	header .search-box {
+		margin-right: 0;
+
+		input {
+			left: 0;
+		}
+	}
+}
+
 @media (max-width: $MQMobile) {
 	header.navbar .links {
 		input {
@@ -65,7 +64,7 @@ header .search-box {
 			font-size: 1rem;
 
 			&:focus {
-				width: 87.5vw;
+				width: calc(100vw - 3rem);
 			}
 		}
 	}


### PR DESCRIPTION
Changes the order of the navbar items to something a bit more usual (logo search nav -> logo, nav, search):

<img width="1123" alt="Screenshot 2020-06-30 at 10 25 12" src="https://user-images.githubusercontent.com/152863/86112958-8a992180-bac0-11ea-88d7-30859c7fe234.png">
