### PR TITLE
Removes drand capitalization where needed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drand documentation
 
-Welcome to the Drand documentation website! We're sorry, but there's no much to see right now. We're in the process of building and writing, so we'll have something for you soon. In the meantime you can check out the [Drand GitHub repository](https://github.com/drand/drand) for more info.
+Welcome to the drand documentation website! We're sorry, but there's no much to see right now. We're in the process of building and writing, so we'll have something for you soon. In the meantime you can check out the [drand GitHub repository](https://github.com/drand/drand) for more info.
 
 ## Project set up
 
@@ -31,7 +31,7 @@ If you want to build this site locally, run the following:
 
 ## Creating a blog post
 
-There are two steps to creating a post for the Drand site:
+There are two steps to creating a post for the drand site:
 
 1. Content management
 1. Sidebar management

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,4 +29,4 @@ Billions of devices around the world use random numbers to keep computers secure
 
 Help the internet by generating truely random numbers with drand. [Manage a node →](/operate)
 
-The Drand project is maintained by contributors from many different fields, companies, and research labs. If you'd like to contribute code, submit issues, improve documentation, or get the word out, [find out how to get involved with the project →](/about)
+The drand project is maintained by contributors from many different fields, companies, and research labs. If you'd like to contribute code, submit issues, improve documentation, or get the word out, [find out how to get involved with the project →](/about)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,10 +1,10 @@
 ---
-title: Drand Documentation
+title: Drand documentation
 description: The home page for developer documentation for drand, a distributed randomness beacon.
 home: true
 heroImage: images/logo-drand-text-bottom-dark.svg
 heroAlt: drand logo
-heroText: Distributed Randomness Beacon.
+heroText: Distributed randomness beacon.
 tagline: Verifiable, unpredictable and unbiased random numbers as a service.
 features:
   - title: HTTP API

--- a/docs/about/README.md
+++ b/docs/about/README.md
@@ -1,5 +1,5 @@
 ---
-title: About the drand project
+title: About
 ---
 
 # About

--- a/docs/about/community.md
+++ b/docs/about/community.md
@@ -5,4 +5,4 @@ description: Join in with the Drand community!
 
 # Community
 
-The Drand project is still in it's early stages, and we're building ways to interact with the community as we continue to build everything. For now, the best way to join in with the community is [through GitHub](https://github.com/drand). In the next few weeks we'll open up a forum and IRC channel for public discussion.
+The drand project is still in it's early stages, and we're building ways to interact with the community as we continue to build everything. For now, the best way to join in with the community is [through GitHub](https://github.com/drand). In the next few weeks we'll open up a forum and IRC channel for public discussion.

--- a/docs/about/community.md
+++ b/docs/about/community.md
@@ -1,6 +1,6 @@
 ---
 title: Community
-description: Join in with the Drand community!
+description: Join in with the drand community!
 ---
 
 # Community

--- a/docs/about/contributing.md
+++ b/docs/about/contributing.md
@@ -1,11 +1,11 @@
 ---
 title: Contributing
-description: Learn how you can help the Drand project by submitting code, fixing bugs, and updating documentation!
+description: Learn how you can help the drand project by submitting code, fixing bugs, and updating documentation!
 ---
 
 # Contributing
 
-Learn how you can help the Drand project by submitting code, fixing bugs, and updating documentation!
+Learn how you can help the drand project by submitting code, fixing bugs, and updating documentation!
 
 ## Core project
 
@@ -19,4 +19,4 @@ This documentation platform is constatly growing, evolving, and being updated. I
 
 ## Submitting issues
 
-Have you found a bug, or have a feature request for the Drand project? All issues can be submitted [through Github](https://github.com/drand/drand/issues).
+Have you found a bug, or have a feature request for the drand project? All issues can be submitted [through Github](https://github.com/drand/drand/issues).

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -4,7 +4,7 @@ title: Blog
 
 # Blog
 
-Here you can find project updates, upcoming events, and breaking news about the Drand project.
+Here you can find project updates, upcoming events, and breaking news about the drand project.
 
 ---
 

--- a/docs/concepts/cryptography.md
+++ b/docs/concepts/cryptography.md
@@ -5,7 +5,7 @@ sidebarDepth: 2
 
 # Cryptography
 
-This document provides an overview of the cryptographic building blocks that Drand uses to generate
+This document provides an overview of the cryptographic building blocks that drand uses to generate
 publicly-verifiable, unbiased, and unpredictable randomness in a distributed manner. The drand beacon has two phases (a setup phase, and a beacon phase), which we describe below.
 
 Generally, we assume that there are $n$ participants, out of which at most $f<n$ are malicious. Drand heavily relies on [threshold cryptography](https://en.wikipedia.org/wiki/Threshold_cryptosystem) primitives, where (at least) a threshold of $t=f+1$ nodes have to work together to execute certain cryptographic operations successfully.
@@ -16,7 +16,7 @@ Threshold cryptography has many applications, as it avoids single points of fail
 
 ## Setup Phase
 
-The purpose of the Drand setup phase is to create a collective private, and public key pair shared among $n$ participants. This is done through a $t$-of-$n$ [Distributed Key Generation (DKG)](https://en.wikipedia.org/wiki/Distributed_key_generation) process at the end of which each of the $n$ participants obtains a copy of the **collective public key**, together with a **private key share** of the **collective private key**. The key shares are computed such that no individual node knows the entire collective private key.
+The purpose of the drand setup phase is to create a collective private, and public key pair shared among $n$ participants. This is done through a $t$-of-$n$ [Distributed Key Generation (DKG)](https://en.wikipedia.org/wiki/Distributed_key_generation) process at the end of which each of the $n$ participants obtains a copy of the **collective public key**, together with a **private key share** of the **collective private key**. The key shares are computed such that no individual node knows the entire collective private key.
 
 Each private key share can then be used to perform cryptographic threshold computations, such as generating threshold signatures, where at least $t$ contributions produced using the individual private key shares are required to successfully finish the collective operation.
 
@@ -27,7 +27,7 @@ A DKG is performed in a fully distributed manner, avoiding any single points of 
 
 [Secret sharing](https://en.wikipedia.org/wiki/Secret_sharing) is an important technique that many advanced threshold cryptography mechanisms rely on. Secret sharing allows one to split a secret value $s$ into $n$ shares $s_1,\ldots,s_n$ such that $s$ can only be reconstructed if a threshold of $t$ shares is available.
 
-[Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) (SSS) scheme is one of the most well-known and widely used secret sharing approaches, and it is a core component of Drand. SSS works over an arbitrary finite field, but for simplicity, we use the integers modulo $p$ denoted by $\mathbb{Z}_p$. Let $s \in \mathbb{Z}_p$ denote the secret to be shared.
+[Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) (SSS) scheme is one of the most well-known and widely used secret sharing approaches, and it is a core component of drand. SSS works over an arbitrary finite field, but for simplicity, we use the integers modulo $p$ denoted by $\mathbb{Z}_p$. Let $s \in \mathbb{Z}_p$ denote the secret to be shared.
 
 **Share Distribution**: To share $s$ a **dealer** first creates a polynomial $q(x) = a_0 + a_1x + ... + a_{t-1}x^{t-1}$ with $a_0 = s$ and (random) $a \in \mathbb{Z}p$ for $i = 1,\ldots,t-1$
 
@@ -78,7 +78,7 @@ We first give an overview of [pairing-based cryptography](https://en.wikipedia.o
 
 Afterward, we show how drand uses PBC in the randomness beacon generation phase for [threshold Boneh-Lynn-Shacham (BLS) signatures](https://en.wikipedia.org/wiki/Boneh%E2%80%93Lynn%E2%80%93Shacham).
 
-Finally, we explain how Drand links the generated threshold BLS signatures into a randomness chain.
+Finally, we explain how drand links the generated threshold BLS signatures into a randomness chain.
 
 ### Pairing-Based Cryptography
 
@@ -95,7 +95,7 @@ Drand currently uses the [BLS12-381 curve](https://electriccoin.co/fr/blog/new-s
 
 ### Randomness Generation
 
-To generate publicly-verifiable, unbiased, distributed randomness, Drand utilizes [threshold Boneh-Lynn-Shacham (BLS) signatures](https://en.wikipedia.org/wiki/Boneh%E2%80%93Lynn%E2%80%93Shacham).
+To generate publicly-verifiable, unbiased, distributed randomness, drand utilizes [threshold Boneh-Lynn-Shacham (BLS) signatures](https://en.wikipedia.org/wiki/Boneh%E2%80%93Lynn%E2%80%93Shacham).
 
 Below we first describe regular [BLS signatures](https://www.iacr.org/archive/asiacrypt2001/22480516.pdf) followed by the threshold variant.
 
@@ -106,7 +106,7 @@ BLS signatures are short signatures that rely on bilinear pairings and consist o
 They are _deterministic_ in the sense that a BLS signature depends only on the message and the signer's key unlike other signature schemes, such as
 [ECDSA](https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm), which requires a fresh random value for each signed message to be secure.
 
-Put differently, any two BLS signatures on a given message produced with the same key are identical. In Drand, we utilize this property to achieve unbiasability for the randomness generation. The BLS signature scheme consists of the following sub-procedures:
+Put differently, any two BLS signatures on a given message produced with the same key are identical. In drand, we utilize this property to achieve unbiasability for the randomness generation. The BLS signature scheme consists of the following sub-procedures:
 
 **Key Generation**: To generate a key pair, a signer first chooses a private key $x \in \mathbb{Z}_p^{\ast}$ at random and then computes the corresponding public key as $X = g_2^x \in \mathbb{G}_2$.
 
@@ -140,7 +140,7 @@ In summary, a threshold BLS signature $\sigma$ exhibits all properties required 
 
 ### Chained Randomness
 
-The Drand randomness beacon operates in discrete rounds $r$. In every round, Drand produces a new random value using threshold BLS signatures which are linked together into a chain of randomness.
+The drand randomness beacon operates in discrete rounds $r$. In every round, drand produces a new random value using threshold BLS signatures which are linked together into a chain of randomness.
 
 To extend this chain of randomness, each drand participant $i$ creates in round $r$ the partial BLS signature $\sigma_i^r$ on the message $m = H(r || \sigma_{r-1})$ where $\sigma_{r-1}$ denotes the (full) BLS threshold signature from round $r - 1$ and $H$ a cryptographic hash function.
 
@@ -150,7 +150,7 @@ At that point, the random value of round $r$ is simply its hash $H(\sigma_r)$.
 
 Afterward, drand nodes move to round $r+1$ and reiterate the above process.
 
-For round $r=0$, Drand participants sign a seed fixed during the Drand setup. This process
+For round $r=0$, drand participants sign a seed fixed during the drand setup. This process
 ensures that every new random value depends on all previously generated signatures. Since the
 signature is deterministic, there is also no possibility for an adversary of forking the chain and presenting two distinct signatures $\sigma_r$ and $\sigma_r^{'}$ in a given round $r$ to generate inconsistencies in the systems relying on public randomness.
 
@@ -158,9 +158,9 @@ In a nutshell, this construction of using the hash of a BLS signature can be con
 
 ## Conclusion
 
-To summarize, Drand is an efficient randomness beacon daemon that utilizes pairing-based cryptography, $t$-of-$n$ distributed key generation, and threshold BLS signatures to generate publicly-verifiable, unbiased, unpredictable, distributed randomness.
+To summarize, drand is an efficient randomness beacon daemon that utilizes pairing-based cryptography, $t$-of-$n$ distributed key generation, and threshold BLS signatures to generate publicly-verifiable, unbiased, unpredictable, distributed randomness.
 
-To learn more about the background of Drand, we refer to the [corresponding slides](https://docs.google.com/presentation/d/1t2ysit78w0lsySwVbQOyWcSDnYxdOBPzY7K2P9UE1Ac/edit?usp=sharing).
+To learn more about the background of drand, we refer to the [corresponding slides](https://docs.google.com/presentation/d/1t2ysit78w0lsySwVbQOyWcSDnYxdOBPzY7K2P9UE1Ac/edit?usp=sharing).
 
 Finally, for more formal background on public randomness, we refer to the research paper titled ["Scalable Bias-Resistant Distributed Randomness"](https://eprint.iacr.org/2016/1067.pdf) published at the [38th IEEE Symposium on Security and Privacy](https://www.ieee-security.org/TC/SP2017/).
 

--- a/docs/concepts/cryptography.md
+++ b/docs/concepts/cryptography.md
@@ -14,7 +14,7 @@ Threshold cryptography has many applications, as it avoids single points of fail
 
 **Note**: This document is intended for a general audience, and no in-depth cryptographic background knowledge is necessary to understand the presented concepts.
 
-## Setup Phase
+## Setup phase
 
 The purpose of the drand setup phase is to create a collective private, and public key pair shared among $n$ participants. This is done through a $t$-of-$n$ [Distributed Key Generation (DKG)](https://en.wikipedia.org/wiki/Distributed_key_generation) process at the end of which each of the $n$ participants obtains a copy of the **collective public key**, together with a **private key share** of the **collective private key**. The key shares are computed such that no individual node knows the entire collective private key.
 
@@ -23,7 +23,7 @@ Each private key share can then be used to perform cryptographic threshold compu
 A DKG is performed in a fully distributed manner, avoiding any single points of failure. We give an overview of the different sub-components of the drand
 [DKG implementation](https://github.com/dedis/kyber/tree/master/share/dkg/pedersen) in the following subsections.
 
-### Secret Sharing
+### Secret sharing
 
 [Secret sharing](https://en.wikipedia.org/wiki/Secret_sharing) is an important technique that many advanced threshold cryptography mechanisms rely on. Secret sharing allows one to split a secret value $s$ into $n$ shares $s_1,\ldots,s_n$ such that $s$ can only be reconstructed if a threshold of $t$ shares is available.
 
@@ -37,7 +37,7 @@ The dealer then creates one share $s_i$ for each participant $i$ by evaluating $
 
 Note that any subset of $t$-of-$n$ shares can be used to perform Lagrange interpolation and uniquely determine $s$. Having any subset of fewer than $t$ shares does not allow one to learn anything about $s$, though.
 
-### Verifiable Secret Sharing
+### Verifiable secret sharing
 
 Shamir's Secret Sharing scheme assumes that the dealer is honest but this assumption might not always hold in practice.
 
@@ -54,7 +54,7 @@ These commitments enable each participant $i$ to verify that their share $s_i = 
 
 **Secret Reconstruction**: The recovery of secret $s$ works as in regular SSS with the difference that verified to be valid shares are used.
 
-### Distributed Key Generation
+### Distributed key generation (DKG)
 
 Although VSS schemes protect against a malicious dealer, the dealer still knows the secret itself. To create a collectively shared secret $s$ such that no individual node gets any information about it, participants can utilize a [Distributed Key Generation](https://en.wikipedia.org/wiki/Distributed_key_generation) (DKG) protocol.
 
@@ -70,7 +70,7 @@ The collective public key associated with the valid shares can be computed as $S
 
 **Note**: Even though the secret created using Pedersen's DKG can be biased, it is safe to use for threshold signing as shown by [Rabin et al.](https://link.springer.com/content/pdf/10.1007%2F3-540-48910-X_21.pdf)
 
-## Beacon Phase
+## Beacon phase
 
 In the previous section, we gave an overview of how to produce a collective distributed key pair via a DKG protocol. In this section, we describe how to use this collective key pair to generate publicly-verifiable, unbiased, and unpredictable randomness in a distributed manner
 
@@ -80,7 +80,7 @@ Afterward, we show how drand uses PBC in the randomness beacon generation phase 
 
 Finally, we explain how drand links the generated threshold BLS signatures into a randomness chain.
 
-### Pairing-Based Cryptography
+### Pairing-based cryptography
 
 Pairing-based cryptography is based on _bilinear groups_ $(\mathbb{G}_1,\mathbb{G}_2,\mathbb{G_t})$ where $\mathbb{G}_1,\mathbb{G}_2,$ and $\mathbb{G_t}$ are cyclic groups of prime order $p$ with generators $g_1$, $g_2$, and $g_t$ respectively, and a pairing operation $e : \mathbb{G}_1  \times \mathbb{G}_2 \to \mathbb{G}_t$ with the following properties:
 
@@ -93,13 +93,13 @@ $\forall a,b \in \mathbb{Z}_p^{\ast}, \forall P \in \mathbb{G}_1, \forall Q \in 
 
 Drand currently uses the [BLS12-381 curve](https://electriccoin.co/fr/blog/new-snark-curve/).
 
-### Randomness Generation
+### Randomness generation
 
 To generate publicly-verifiable, unbiased, distributed randomness, drand utilizes [threshold Boneh-Lynn-Shacham (BLS) signatures](https://en.wikipedia.org/wiki/Boneh%E2%80%93Lynn%E2%80%93Shacham).
 
 Below we first describe regular [BLS signatures](https://www.iacr.org/archive/asiacrypt2001/22480516.pdf) followed by the threshold variant.
 
-#### BLS Signature
+#### BLS signature
 
 BLS signatures are short signatures that rely on bilinear pairings and consist only of a single element in $\mathbb{G}_1$.
 
@@ -118,7 +118,7 @@ To compute a BLS signature $\sigma$ on a message $m$, the signer simply computes
 
 It is easy to see that this equation holds for valid signatures since $e(H(m),X) = e(H(m),g_2^x) = e(H(m),g_2)^x = e(xH(m),g_2) = e(\sigma,g_2)$
 
-#### Threshold BLS Signatures
+#### Signature threshold
 
 The goal of a threshold signature scheme is to collectively compute a signature by combining individual partial signatures independently generated by the participants. A threshold BLS signature scheme has the following sub-procedures:
 
@@ -138,7 +138,7 @@ Additionally, Lagrange interpolation also guarantees that no set of less than $t
 
 In summary, a threshold BLS signature $\sigma$ exhibits all properties required for publicly-verifiable, unbiased, unpredictable, and distributed randomness.
 
-### Chained Randomness
+### Chained randomness
 
 The drand randomness beacon operates in discrete rounds $r$. In every round, drand produces a new random value using threshold BLS signatures which are linked together into a chain of randomness.
 

--- a/docs/concepts/overview.md
+++ b/docs/concepts/overview.md
@@ -1,6 +1,6 @@
 ---
 title: Overview
-description: Learn about the basics of Drand, how it works, and why it exists in the first place.
+description: Learn about the basics of drand, how it works, and why it exists in the first place.
 ---
 
 # Overview
@@ -29,7 +29,7 @@ There have been cases where attackers have rigged lotteries and elections by inf
 - Decentralized: a set of independent parties produces random numbers.
 - Always available: the system must always be able to provide random numbers.
 
-The Drand project aims to create a random number generator that has all five of these properties.
+The drand project aims to create a random number generator that has all five of these properties.
 
 ## How drand works
 
@@ -43,7 +43,7 @@ This is an incredibly simplified outline of how drand works. Check out the proje
 
 ## Public randomness
 
-Generating public randomness is the primary functionality of Drand. Public randomness is generated collectively by Drand nodes and made publicly available. The main challenge in generating good randomness is that no party involved in the randomness generation process should be able to predict or bias the final output. Additionally, the final result has to be verifiable by a third-party to make it actually useful for applications like lotteries, sharding, or parameter generation in security protocols.
+Generating public randomness is the primary functionality of drand. Public randomness is generated collectively by drand nodes and made publicly available. The main challenge in generating good randomness is that no party involved in the randomness generation process should be able to predict or bias the final output. Additionally, the final result has to be verifiable by a third-party to make it actually useful for applications like lotteries, sharding, or parameter generation in security protocols.
 
 A drand randomness beacon is composed of a distributed set of nodes and has two phases:
 

--- a/docs/concepts/security-model.md
+++ b/docs/concepts/security-model.md
@@ -3,7 +3,7 @@ title: Security model
 sidebarDepth: 2
 ---
 
-# Security Model of drand
+# Security model of drand
 
 ## Notations
 
@@ -33,13 +33,13 @@ document tries to clarify in which context when relevant.
 the context) and sends packets out to the Internet that are correctly received by
 the endpoint(s).
 
-## Security Model
+## Security model
 
 In drand, there are two phases which do not require the same security
 assumptions. This section highlights both models and the practical realization
 or assumptions taken.
 
-### Distributed Key Generation Ceremony (setup phase)
+### Distributed key generation set up
 
 The DKG protocol model follows the one from the Pedersen's protocol. [Gennaro's paper](https://www.researchgate.net/publication/225722958_Secure_Distributed_Key_Generation_for_Discrete-Log_Based_Cryptosystems) explains the protocol and its assumptions.
 
@@ -137,14 +137,14 @@ For this to happen, there needs to be at least `tA` nodes from network A and
 there are going to be at least `tB` nodes that are qualified and have private shares
 to generate randomness.
 
-## Attack Vectors
+## Attack vectors
 
-### Randomness Generation
+### Randomness generation
 
 There can be multiple ways of attacking the drand network during the randomness
 generation phase, each with different consequences.
 
-#### Front Running
+#### Front running
 
 1. Passive Adversary Scenario
 
@@ -251,7 +251,7 @@ the initial group now.
 As such, it is recommended to reshare often, _even if_ between the same nodes,
 as it creates new shares.
 
-### Distributed Key Generation Ceremony
+### Distributed key generation ceremony
 
 #### DoS attacks
 
@@ -279,7 +279,7 @@ DKG. This scenario is similar to the scenario 2 for the randomness generation
 since even before the DKG: attacker can know before the end of the DKG the whole
 randomness chain (since he can see the honest shares before sending them).
 
-#### Broadcast Channel Assumption
+#### Broadcast channel assumption
 
 Attacker is at least one node in the group and broadcasts inconsistent shares
 and public polynomial to different parties. Given drand does not use a

--- a/docs/concepts/security-model.md
+++ b/docs/concepts/security-model.md
@@ -1,5 +1,5 @@
 ---
-title: Security Model
+title: Security model
 sidebarDepth: 2
 ---
 

--- a/docs/concepts/specification.md
+++ b/docs/concepts/specification.md
@@ -2,7 +2,7 @@
 title: Specification
 ---
 
-# Drand Specifications
+# Drand specifications
 
 Drand (pronounced "dee-rand") is a distributed randomness beacon daemon written
 in Golang. Servers running drand can be linked with each other to produce
@@ -81,7 +81,7 @@ though it doesn't expose private key materials it non-essential information from
 the point of view of users. A public struct derived from the group to share to
 clients is described in the [root of trust section](#root-of-trust).
 
-#### Group Configuration Hash
+#### Group configuration hash
 
 The group configuration can be uniquely referenced via its canonical hash. The
 hash of the group file is used during a resharing procedure to make sure node
@@ -121,7 +121,7 @@ file for the intra-nodes protocols and in the
 [api.proto](https://github.com/drand/drand/blob/master/protobuf/drand/api.proto)
 file.
 
-## Drand Modules
+## Drand modules
 
 Generating public randomness is the primary functionality of drand. Public
 randomness is generated collectively by drand nodes and publicly available. The
@@ -263,7 +263,7 @@ generation. All nodes that receive the first packet of the DKG from the
 coordinator (or else, due to network shifts) must send their first packet of the
 DKG as well and start the ticker as explained below.
 
-### Distributed Key Generation
+### Distributed key generation
 
 The distributed key generation protocol implements the Pedersen's protocol, best
 described from [Gennaro's
@@ -375,7 +375,7 @@ messages of the phase from all other nodes already. In more details:
 The phases and the respective messages are described in more details in the
 following sections.
 
-#### Deal Phase
+#### Deal phase
 
 In this first phase, nodes sends their "deal" containing their encrypted share
 to the other nodes as well as the public polynomial from which those shares are
@@ -411,7 +411,7 @@ directly transition to the `ResponsePhase`. Otherwise, the node needs to wait
 until the ticker kicks in for the next timeouts, before entering the
 `ResponsePhase`.
 
-#### Response Phase
+#### Response phase
 
 In this second phase, each node first process all their deals received during
 the previous phase. Each nodes then sends a Response for each shares they have
@@ -450,7 +450,7 @@ ticker kicks in, the node decides to which phase to proceed to:
   can directly go into the `FinishPhase` and compute their final share.
 - If not, then the node needs to go into the `JustificationPhase`.
 
-#### Justification Phase
+#### Justification phase
 
 For each "complaint" responses (i.e. `status == false`) whose`dealer_index` is
 equal to their index, a node sends a `Justification` packet that contains the
@@ -481,7 +481,7 @@ message Justification {
 A node can silently waits until it receives all justification expected or the
 ticker kicks in to go into the `FinishPhase`.
 
-#### Finish Phase
+#### Finish phase
 
 In the `FinishPhase`, each node locally look at the shares they received and
 compute both their final share and the distributed public key. For the DKG to be
@@ -513,7 +513,7 @@ Note here that the hash function shown here is simply an example, a suggestion.
 An application is free to hash the signature using any secure hash function. The
 important point is to verify to validity of the signature.
 
-#### Randomness Generation Period
+#### Randomness generation period
 
 The drand network outputs a new random beacon every period and associates a
 beacon "round" to a specific time. The mapping between a time and a round allows
@@ -549,7 +549,7 @@ is always enough honest nodes such that the chain advances at the correct speed.
 In case this is not true at some point in time, please refer to the [catchup
 section](#catchup) for more information.
 
-#### Beacon Chain
+#### Beacon chain
 
 Drand binds the different random beacon together so they form a chain of random
 beacons. Remember a drand beacon is structured as follow:
@@ -572,7 +572,7 @@ type Beacon struct {
 This structure makes it so that each beacon created is building on the previous
 one therefor forming a randomness chain.
 
-**Partial Beacon Creation**: At each new round, a node creates a `PartialBeacon`
+**Partial beacon creation**: At each new round, a node creates a `PartialBeacon`
 with the current round number, the previous signature and the partial signature
 over the message:
 
@@ -596,7 +596,7 @@ previousSignature = lastBeacon.Signature
 It is important to note that the current round may not be necessarily the round
 of the current time. More information in the following section.
 
-**Partial Beacon Broadcast**:Each node then calls the following RPC call
+**Partial beacon broadcast**:Each node then calls the following RPC call
 
 ```protobuf
 rpc PartialBeacon(PartialBeaconPacket) returns (drand.Empty);
@@ -617,7 +617,7 @@ message PartialBeaconPacket {
 }
 ```
 
-**Final Beacon Creation**: For each incoming partial beacon packet, a
+**Final beacon creation**: For each incoming partial beacon packet, a
 node must first verify it, using the partial signature verification routine and
 then stores it in a temporary cache if it is valid. As soon as there is at
 least a threshold of valid partial signatures, the node can aggregate them to
@@ -678,7 +678,7 @@ genesis time). At each kicks, a node loads its last beacon generated and runs
 the protocol as shown above. Under normal circumstances, the `Round` field
 should be the round that corresponds to the current time.
 
-**Network Halting**: However, it may happen that there is not enough partial
+**Network halting**: However, it may happen that there is not enough partial
 beacon being broadcasted at one time therefore there will not be any random
 beacon created for this round. Under these circumstances, nodes can enter a
 "catchup" mode.
@@ -701,7 +701,7 @@ If the sync didn't return any more recent valid beacons, that probably means the
 network is stalled. In that case, nodes must continue to broadcast the same
 partial beacon as usual at every tick.
 
-**Network Catchup**: At some point, there will be enough honest & alive nodes to
+**Network catchup**: At some point, there will be enough honest & alive nodes to
 broadcast their partial signatures such that a new beacon can be aggregated, for
 the round R. However, that round R does not correspond to the current round
 given their local clock. In this situation, each node must produce their partial
@@ -769,7 +769,7 @@ given round requested and sends back all subsequent beacons until the last one.
 
 ## Cryptographic specification
 
-### Drand Curve
+### Drand curve
 
 Drand uses the pairing curve
 [BLS12-381](https://hackmd.io/@benjaminion/bls12-381). All points on the curve are sent using the compressed form.
@@ -799,7 +799,7 @@ Two polynomials can be added in the following way:
 f(x) + g(x) = (f_0 + g_0) + (f_1 + g_1) * x + ...
 ```
 
-### Distributed Public Key
+### Distributed public key
 
 The distributed public key is a list of BLS12-381 G1 points that represents the
 public polynomial created during the DKG protocol.
@@ -818,7 +818,7 @@ type DistPublic struct {
 The coefficients are needed to verify partial beacon signatures.
 The first coefficient is needed to verify the final beacon signature.
 
-### Beacon Signature
+### Beacon signature
 
 A beacon signature is a regular [BLS signature](https://www.iacr.org/archive/asiacrypt2001/22480516.pdf) over the message:
 
@@ -840,7 +840,7 @@ var Domain = []byte("BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_NUL_")
 A beacon signature can be verified using the first coefficient of the distributed public key
 stored in the group configuration:
 
-### Partial Beacon Signature
+### Partial beacon signature
 
 A partial beacon signature is created over the same input as the beacon
 signature. However, the node's index is prefixed on the first two bytes to the
@@ -877,7 +877,7 @@ func Eval(i int,commits []Point) Point {
 }
 ```
 
-### Distributed Key Generation
+### Distributed key generation
 
 This sections presents the cryptographic operations and safety checks each node
 must perform during the three phases of the DKG.
@@ -926,7 +926,7 @@ The matrix must be initialized as having only incorrect shares for all dealers
 at the beginning. This effectively forces all share holders to explicitely
 broadcast that the shares they receives are correct.
 
-#### Deal Phase
+#### Deal phase
 
 During this phase, each node must create a valid encrypted "share" to each other
 node. A share is simply the evaluation of the private polynomial at the index of
@@ -956,7 +956,7 @@ polynomial to the encrypted shares in the same packet `DealBundle`. Then each
 node must signs the packet and embeds the signature in a `AuthDealBundle`
 packet.
 
-#### Response Phase
+#### Response phase
 
 **Processing of the shares**:
 At the beginning of this phase, the node must first process all published deals
@@ -999,7 +999,7 @@ all dealers and create a response with the same status. Each node bundles these
 responses into a `ResponseBundle`, signs it and wraps it into a
 `AuthResponseBundle` and broadcasts that packet.
 
-#### Justification Phase
+#### Justification phase
 
 **Processing of the responses**: For each responses received, each node sets the
 status of the share index from the dealer index as designated in the response.
@@ -1021,7 +1021,7 @@ into the `FinishPhase` already at this point: If all shares of all dealers are
 "valid", then the node can go into the `FinishPhase`. Otherwise, a node needs to
 run the following logic.
 
-**Validating Justifications**: Each node runs the following logic on all
+**Validating justifications**: Each node runs the following logic on all
 received `AuthJustifBundle`:
 
 ```text
@@ -1051,7 +1051,7 @@ For each bundle:
 After processing the justifications, each node can pass into the `FinishPhase`
 logic.
 
-#### Finish Phase
+#### Finish phase
 
 In the finish phase, each node locally computes their final share and the
 distributed public key. At the end, each node can distribute the public key and
@@ -1091,7 +1091,7 @@ previous section.
 
 #### Setup
 
-**Private Polynomial**: Each dealer creates its private polynomial from the
+**Private polynomial**: Each dealer creates its private polynomial from the
 **share of the node** that the node generated in group A. Namely, the free
 coefficient of the private polynomial is the share:
 
@@ -1102,10 +1102,10 @@ f(x) = share + c_1 * x + ... + c_{t-1} * x^{t-1}
 **NOTE**:The length of the polynomial is set to the threshold of the new group, of the
 group B.
 
-**Public Polynomial**: This is created the same way as in the fresh dkg, by
+**Public polynomial**: This is created the same way as in the fresh dkg, by
 commiting the private polynomial.
 
-#### Distinction of Roles
+#### Distinction of roles
 
 In the resharing case, there is a group A and a group B of nodes which can be
 completely disjoint. Each node in group A has a specific index and each node in
@@ -1121,7 +1121,7 @@ Note a node can now have two indexes if it belongs to the group A and group B.
 We call theses indexes DealerIndex and ShareIndex as consistent with the
 previous notation in the DKG case.
 
-#### Deal Phase
+#### Deal phase
 
 The deal phase is essentially the same except for the index where the node
 evaluate the private polynomial. A dealer evaluates its private polynomial on
@@ -1143,7 +1143,7 @@ for n in shareHolders:
 return shares
 ```
 
-#### Response Phase
+#### Response phase
 
 There are two main differences with respect to the responses phase in a fresh
 dkg:
@@ -1205,7 +1205,7 @@ For each bundle:
 filled with the index of the share holder index, whereas in the fresh DKG, the
 index is the same as DealerIndex.
 
-#### Justification Phase
+#### Justification phase
 
 At this point, nodes that are only in group A and not in group B, i.e. leaving
 the network can abort the protocol now: their contribution is not needed
@@ -1216,7 +1216,7 @@ DKG case.
 
 **Deciding upon next phase**: It is the same step as in the fresh DKG case.
 
-**Validating Justifications**: The logic is mostly the same, except that each
+**Validating justifications**: The logic is mostly the same, except that each
 node needs also to validate that the dealer is indeed "re-sharing its share":
 the dealer used the commitment of its share as the free coefficient of the
 public polynomial he advertised during the deal phase.
@@ -1253,7 +1253,7 @@ For each bundle:
               dealer "bundle.DealerIndex"
 ```
 
-#### Finish Phase
+#### Finish phase
 
 The finish phase in case of a resharing is where the the major differences rises
 with respect to a fresh DKG protocol.
@@ -1329,7 +1329,7 @@ For i in 0..thresholdB:
 return new_coeffs
 ```
 
-**Qualified Nodes Selection**: We need to augment the normal selection rule from
+**Qualified nodes selection**: We need to augment the normal selection rule from
 the fresh DKG case with a new rule to exclude absent new nodes from group B.
 
 ```text

--- a/docs/concepts/specification.md
+++ b/docs/concepts/specification.md
@@ -60,7 +60,7 @@ about a running drand network:
 - Nodes: A list of nodes information that represents all nodes on the network.
 - Threshold: The number of nodes that are necessary to participate to a
   randomness generation round to produce a new random value. Given the security
-  model of Drand, the threshold must be superior to 50% of the number of nodes.
+  model of drand, the threshold must be superior to 50% of the number of nodes.
 - Period: The period at which the network creates new random value
 - GenesisTime: An UNIX timestamp in seconds that represents the time at which
   the first round of the drand chain starts. See the [beacon
@@ -355,7 +355,7 @@ Example:
   `JustificationPhase` _if there was no complaint response received_ OR in
   `FinishPhase` otherwise.
 
-**Fast Sync**: Drand uses a _fast sync_ mode that allows to make the setup
+**Fast Sync**: drand uses a _fast sync_ mode that allows to make the setup
 phase proceeds faster at the cost of higher bandwidth usage. Given the
 relatively low size of the network, the latter is not a concern. The general
 idea is to move to the next step before the ticker kicks in if we received the

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -4,17 +4,17 @@ title: 'API and Client Library Documentation'
 
 # Docs
 
-This section helps you build applications that use Drand as a source of randomness. For help running a Drand network, see the [Operator's Guide](../operators/).
+This section helps you build applications that use drand as a source of randomness. For help running a drand network, see the [Operator's Guide](../operators/).
 
-There are several ways to consume randomness from a Drand network:
+There are several ways to consume randomness from a drand network:
 
 - [Fetching randomness over HTTP](#fetching-randomness-over-http)
-- [Using a Drand client library](#using-a-drand-client-library)
+- [Using a drand client library](#using-a-drand-client-library)
 - [Using the `drand` binary](#using-the-drand-command-to-fetch-randomness)
 
 ## Fetching randomness over HTTP
 
-Drand provides an HTTP interface that clients can use to fetch randomness from the Drand network.
+Drand provides an HTTP interface that clients can use to fetch randomness from the drand network.
 
 All that's required is the address of the HTTP interface and way to fetch from HTTP, e.g. `curl`:
 
@@ -37,8 +37,8 @@ procedure and instructions on how to use it, refer to the readme.
 
 ## Using the `drand` command to fetch randomness
 
-The `drand` command can be used to fetch randomness from a running Drand network. To do so, you'll need the group configuration file,
-which can be obtained from a Drand node operator using the [`drand show group` command](../operators/drand-cli/#drand-show).
+The `drand` command can be used to fetch randomness from a running drand network. To do so, you'll need the group configuration file,
+which can be obtained from a drand node operator using the [`drand show group` command](../operators/drand-cli/#drand-show).
 
 Once you have the group file, the latest randomness can be obtained with `drand get public`. The output will be in the same JSON format
 as when fetching via HTTP. For more information, see the [Command Line Tools section](/operators/drand-cli/#drand-get).

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -29,7 +29,7 @@ curl <address>/public/latest
 > }
 ```
 
-## Using DrandJS
+## Using drand.js
 
 Drand can easily be used from JavaScript using [DrandJS](https://github.com/drand/drandjs). The main `fetchAndVerify` method of this JavaScript
 library fetches from a drand node the latest random beacon generated and then verifies it against the distributed key. For more details on the

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -1,5 +1,5 @@
 ---
-title: 'API and Client Library Documentation'
+title: 'API and client library documentation'
 ---
 
 # Docs

--- a/docs/operate/deploy.md
+++ b/docs/operate/deploy.md
@@ -1,6 +1,6 @@
 ---
 title: Deploying a Drand Network
-description: Learn how to deploy a Drand node onto your network.
+description: Learn how to deploy a drand node onto your network.
 sidebarDepth: 2
 ---
 

--- a/docs/operate/deploy.md
+++ b/docs/operate/deploy.md
@@ -1,5 +1,5 @@
 ---
-title: Deploying a Drand Network
+title: Deploy
 description: Learn how to deploy a drand node onto your network.
 sidebarDepth: 2
 ---

--- a/docs/operate/deploy.md
+++ b/docs/operate/deploy.md
@@ -29,7 +29,7 @@ This document explains how to do the setup with the drand binary itself. drand
 also offers a docker image to run the setup. You can find the information for
 running with docker [here](https://github.com/drand/drand/blob/master/docker/README.md).
 
-### Long-Term Key
+### Long-term key
 
 To generate the long-term key pair `drand_id.{secret,public}` of the drand
 daemon, execute
@@ -254,7 +254,7 @@ user-specified entropy source is used. Its use should be limited to testing.
 drand share <group-file> --source <entropy-exec> --user-source-only
 ```
 
-## Distributed Key Generation
+## Distributed key generation (DKG)
 
 Once the DKG phase is done, each node has both a private share and a group file
 containing the distributed public key. Using the previous commands shown, the
@@ -270,7 +270,7 @@ drand show group
 It will print the group file in its regular TOML format. If you want to save it
 to a file, append the `--out <file>` flag.
 
-## Randomness Generation
+## Randomness generation
 
 After a successful setup phase, drand will switch to the randomness generation
 mode _at the genesis time_ specified in the group file they agreed to upon. At
@@ -325,7 +325,7 @@ beacon generated contained `round: 10`), and back up again at round 20 (i.e.
 field `round: 20`), then this new randomness contains the field
 `previous_round:10`.
 
-## Control Functionalities
+## Control functionalities
 
 Drand's local administrator interface provides further functionality, e.g., to
 update group details or retrieve secret information. By default, the daemon
@@ -339,7 +339,7 @@ drand start --control 1234
 In that case, you need to specify the control port for each of the following
 commands.
 
-### Long-Term Private Key
+### Long-term private key
 
 To retrieve the long-term private key of our node, run:
 
@@ -347,7 +347,7 @@ To retrieve the long-term private key of our node, run:
 drand show private
 ```
 
-### Long-Term Public Key
+### Long-term public key
 
 To retrieve the long-term public key of our node, run:
 
@@ -355,7 +355,7 @@ To retrieve the long-term public key of our node, run:
 drand show public
 ```
 
-### Private Key Share
+### Private key share
 
 To retrieve the private key share of our node, as determined during the DKG,
 run the following command:
@@ -381,7 +381,7 @@ scalar and points on the curve, even though scalars are the same on the three
 groups of bls12-381. The field is present already to be able to accommodate
 different curves later on.
 
-### Chain Information
+### Chain information
 
 To retrieve the chain information this node participates to, run:
 
@@ -389,7 +389,7 @@ To retrieve the chain information this node participates to, run:
 drand show chain-info
 ```
 
-## Updating Drand Group
+## Updating drand group
 
 Drand allows for "semi-dynamic" group update with a _resharing_ protocol that
 offers the following:

--- a/docs/operate/docker.md
+++ b/docs/operate/docker.md
@@ -83,7 +83,7 @@ by:
 
 This guide will continue focusing on drand; jump to the end of this guide to configure the reverse proxy.
 
-## Public HTTP api
+## Public HTTP API
 
 The compose file also opens a public http API to be consumed by the clients.
 This public endpoint is exposed on the 8081 port (specified with `--public-listen`]).
@@ -121,7 +121,7 @@ To check what is happening, access the docker-compose logs via
 docker-compose logs
 ```
 
-## Distributed Key Generation
+## Distributed key generation (DKG)
 
 If you did the setup above, you have a container running the drand deamon, loaded with your keys. It still misses two things:
 

--- a/docs/operate/drand-cli.md
+++ b/docs/operate/drand-cli.md
@@ -5,10 +5,10 @@ sidebarDepth: 2
 
 # Drand Command Line Tools
 
-Drand's main functionality is provided by the `drand` program, which allows you to run a Drand server and control its operation. You can also
-use `drand` as a client to fetch randomness from a Drand network.
+Drand's main functionality is provided by the `drand` program, which allows you to run a drand server and control its operation. You can also
+use `drand` as a client to fetch randomness from a drand network.
 
-See the [Supplemental Tools](#supplemental-tools) for some other helpful tools for scaling Drand, as well as a standalone client for consuming
+See the [Supplemental Tools](#supplemental-tools) for some other helpful tools for scaling drand, as well as a standalone client for consuming
 randomness.
 
 ## Installing `drand`
@@ -47,7 +47,7 @@ of `make install`. This will create the `drand` binary in the current directory.
 ## Usage
 
 This section gives a basic overview of the main `drand` CLI interface to give an idea of the options available.
-If you're setting up a Drand network deployment, please see the [Deployment Guide](./deploy.md), which walks through
+If you're setting up a drand network deployment, please see the [Deployment Guide](./deploy.md), which walks through
 using `drand` to run a live network.
 
 The `drand` command has several subcommands. Among the most important is `drand help`, which will introduce you to
@@ -160,7 +160,7 @@ OPTIONS:
 
 `drand` exposes up to four endpoints, depending on the flags passed in.
 
-The **private Drand API endpoint** is used to communicate with other nodes using gRPC. The private API is always enabled.
+The **private drand API endpoint** is used to communicate with other nodes using gRPC. The private API is always enabled.
 If no flag is given, `drand` will bind to the address used when [generating the node's keypair](#drand-generate-keypair).
 If you want `drand` to listen on a different interface and/or port, you can pass the `--private-listen` flag and
 specify the `host:port` to bind to. Note that the addresss associated with the keypair must be publicly accessible
@@ -192,7 +192,7 @@ information and is safe to expose to the internet. Alternatively, you may keep t
 expose randomness to the public with the help of a relay server such as [`drand-relay-http`](#drand-relay-http).
 
 Finally, the **metrics endpoint** provides an API for observing runtime metrics about the drand node. It can be enabled
-with the `--metrics <metrics-port>` flag. See [Drand Metrics](./metrics/) for more details on accessing the metrics.
+with the `--metrics <metrics-port>` flag. See [drand Metrics](./metrics/) for more details on accessing the metrics.
 
 ::: danger
 The metrics API may expose sensitive information about the running `drand` daemon, and should not be exposed to the public internet.
@@ -226,8 +226,8 @@ when running `drand stop`.
 The `share` command tells the `drand` daemon to begin the Distributed Key Generation (DKG) protocol to create private key shares
 with the other Drand nodes.
 
-The `share` command must be used when setting up a new Drand network before randomness generation can begin. It may also be
-used after the network is running to "re-share" the key material, which allows us to change the members of the Drand network
+The `share` command must be used when setting up a new drand network before randomness generation can begin. It may also be
+used after the network is running to "re-share" the key material, which allows us to change the members of the drand network
 without interrupting the generation of randomness.
 
 For details about to running the initial DKG, see the [Deployment Guide](./deploy/).
@@ -262,14 +262,14 @@ in the address of the leader. All of the nodes must specify the following values
 
 - `--secret` - a secret value, shared out-of-band with the other node operators. When re-sharing, this may be distinct from
   the secrets used for any prior DKG rounds.
-- `--period` - sets the interval between rounds of the Drand beacon chain. This must be a string that's parse-able by Golang's
+- `--period` - sets the interval between rounds of the drand beacon chain. This must be a string that's parse-able by Golang's
   [time.ParseDuration function](https://golang.org/pkg/time/#ParseDuration), for example "30s" or "1m".
 - `--nodes` - the number of nodes expected to take part in the DKG. Note that the DKG will succeed even if fewer nodes participate,
   so long as there are enough to meet the threshold.
 - `--threshold` - the number of nodes required to generate randomness. The DKG will fail if fewer than `threshold` nodes participate
   in the DKG before the timeout.
 
-When re-sharing to nodes that are not members of the existing Drand group, the new nodes must obtain a copy of the group configuration file
+When re-sharing to nodes that are not members of the existing drand group, the new nodes must obtain a copy of the group configuration file
 from an existing member, and use the `--from <group-file-path>` flag to specify the path to the `group.toml` file. Members of
 the existing group may omit the `--from` flag, as they already posess the current group configuration.
 
@@ -281,8 +281,8 @@ but should not be used in production.
 
 ### `drand get`
 
-The `get` command allows you to fetch public information from a running Drand node, including random values and the public
-distributed key. Note that you do not need to be a node operator or a member of the Drand group in order to use `drand get`,
+The `get` command allows you to fetch public information from a running drand node, including random values and the public
+distributed key. Note that you do not need to be a node operator or a member of the drand group in order to use `drand get`,
 but you will need a copy of the group configuration file. You will also need access to the gRPC API endpoint, which may be
 protected by firewall rules.
 
@@ -291,7 +291,7 @@ There are three main subcommands for `drand get`:
 - `drand get public <path-to-group.toml>` returns the latest public random value from the group described in `group.toml`.
   You may fetch a specific round instead of the latest by supplying the `--round <round-number>` flag.
 - `drand get private <path-to-group.toml>` sends an encrypted request for private randomness to one of the nodes in `group.toml`.
-- `drand get cokey <path-to-group.toml>` returns the distributed public key shared by all Drand nodes in the `group.toml`.
+- `drand get cokey <path-to-group.toml>` returns the distributed public key shared by all drand nodes in the `group.toml`.
 
 For full usage information, run `drand get --help`.
 
@@ -327,7 +327,7 @@ For full usage information, run `drand util --help`.
 ## Supplemental Tools
 
 In addition to the main `drand` cli app, there are several supplemental tools that can be used to consume randomness from
-a Drand network or help securely scale a Drand deployment.
+a drand network or help securely scale a drand deployment.
 
 The following tools do not yet have binary releases and must be installed from source. The basic procedure is the same
 as [installing drand from source](#source-code), but instead of `make install` or `make build`, you'll run one of:
@@ -338,9 +338,9 @@ as [installing drand from source](#source-code), but instead of `make install` o
 
 ### `drand-client`
 
-The `drand-client` command is a standalone Drand client that's optimized to fetch randomness from a Drand network and provide it over a CDN.
+The `drand-client` command is a standalone drand client that's optimized to fetch randomness from a drand network and provide it over a CDN.
 
-The client is configured with the URL for a Drand HTTP endpoint, and may optionally be configured with the addresses of one or more
+The client is configured with the URL for a drand HTTP endpoint, and may optionally be configured with the addresses of one or more
 libp2p relay nodes. If libp2p relays are configured, the HTTP endpoint will be used as a fallback if the libp2p relays fail to deliver
 randomness at the expected interval.
 
@@ -359,6 +359,6 @@ To see full usage information, run `drand-relay-http help`.
 
 ### `drand-relay-gossip`
 
-The `drand-relay-gossip` command provides a relay server that connects to a Drand node over gRPC and provides randomness to consumers over
+The `drand-relay-gossip` command provides a relay server that connects to a drand node over gRPC and provides randomness to consumers over
 a [libp2p PubSub](https://docs.libp2p.io/concepts/publish-subscribe/) topic. Randomness provided by a gossip relay may be consumed directly
 over PubSub by libp2p-capable programs, and/or via a CDN which has been configured to listen to a PubSub topic using `drand-client`.

--- a/docs/operate/drand-cli.md
+++ b/docs/operate/drand-cli.md
@@ -1,5 +1,5 @@
 ---
-title: Drand Command Line Tools
+title: Command-line tools
 sidebarDepth: 2
 ---
 

--- a/docs/operate/drand-cli.md
+++ b/docs/operate/drand-cli.md
@@ -3,7 +3,7 @@ title: Command-line tools
 sidebarDepth: 2
 ---
 
-# Drand Command Line Tools
+# Command-line tools
 
 Drand's main functionality is provided by the `drand` program, which allows you to run a drand server and control its operation. You can also
 use `drand` as a client to fetch randomness from a drand network.
@@ -11,9 +11,9 @@ use `drand` as a client to fetch randomness from a drand network.
 See the [Supplemental Tools](#supplemental-tools) for some other helpful tools for scaling drand, as well as a standalone client for consuming
 randomness.
 
-## Installing `drand`
+## Installing drand
 
-### Binary Releases
+### Binary releases
 
 The simplest way to get `drand` is to [download a pre-built binary release](https://github.com/drand/drand/releases) for your platform.
 
@@ -24,7 +24,7 @@ contains the SHA-256 checsum for each release archive. To check your local downl
 shasum -a 256 <path-to-drand.tar.gz>
 ```
 
-### Source Code
+### Source code
 
 You can compile `drand` from source code by cloning the [drand GitHub repository](https://github.com/drand/drand) and building the project.
 
@@ -198,7 +198,7 @@ with the `--metrics <metrics-port>` flag. See [drand Metrics](./metrics/) for mo
 The metrics API may expose sensitive information about the running `drand` daemon, and should not be exposed to the public internet.
 :::
 
-#### TLS Configuration
+#### TLS configuration
 
 The `--tls-cert` and `--tls-key` commands give the path to TLS certificates and keys needed for `drand` to provide TLS protection
 to its connections with other `drand` nodes. If you are using a reverse proxy as described in the [Deployment Guide](./deploy/),
@@ -324,7 +324,7 @@ The `util` command provides several subcommands that are useful for debugging an
 
 For full usage information, run `drand util --help`.
 
-## Supplemental Tools
+## Supplemental tools
 
 In addition to the main `drand` cli app, there are several supplemental tools that can be used to consume randomness from
 a drand network or help securely scale a drand deployment.

--- a/docs/operate/metrics.md
+++ b/docs/operate/metrics.md
@@ -2,12 +2,12 @@
 title: Drand metrics
 ---
 
-# Drand Metrics
+# Drand metrics
 
 Drand uses [prometheus](https://prometheus.io/) instrumentation for helping
 operators monitor and understand the runtime behavior of system.
 
-## Local Metrics
+## Local metrics
 
 The local drand node exposes metrics on an HTTP server listening as specified
 by the `--metrics` comamnd line flag. You can view the reported metrics
@@ -17,7 +17,7 @@ in a browser at `http://localhost:<metrics port>/metrics`. This page includes
 - Statistics on the drand beacon and group behavior
 - Statistics on the HTTP public listener request load if enabled.
 
-## Shared Group Metrics
+## Shared group metrics
 
 In addition to the metrics collected within the local node, the drand
 GRPC group protocol supports re-export and sharing of group metrics
@@ -30,7 +30,7 @@ the node. It is meant to allow better visibility when debugging
 network issues, and helping operators understand where problems
 originate.
 
-# Drand Client Metrics
+# Drand client metrics
 
 The drand client is capable of collecting metrics on the health of the sources
 of randomness that it is connected to.

--- a/docs/operate/metrics.md
+++ b/docs/operate/metrics.md
@@ -32,15 +32,15 @@ originate.
 
 # Drand Client Metrics
 
-The Drand client is capable of collecting metrics on the health of the sources
+The drand client is capable of collecting metrics on the health of the sources
 of randomness that it is connected to.
 
 For each HTTP endpoint, every 10 seconds, the client sends "heartbeat"
 requests for the "current" randomness, wherein the requested "current" randomness round
-is calculated based on the current time and the genenesis time of the Drand network.
+is calculated based on the current time and the genenesis time of the drand network.
 The outcomes of these requests are used to generate the following metrics:
 
-- _Heartbeat latency_: This is the duration, in milliseconds, between the time when the randomness response was received and the time when it was meant to be produced by the Drand nodes (based on the genesis time of the network and the round number). The corresponding Prometheus metric is the gauge `client_http_heartbeat_latency`. In normal conditions, when the network latency is sub-second, one expects the heartbeat latency to be roughly evenly distributed between 0 and 30 seconds. This is caused by the fact that there are multiple heartbeats during a single round, which lasts 30 seconds, as well as the fact that each request blocks until the randomness becomes available. This metric is implemented in [https://github.com/drand/drand/blob/master/client/http/metric.go#L59].
+- _Heartbeat latency_: This is the duration, in milliseconds, between the time when the randomness response was received and the time when it was meant to be produced by the drand nodes (based on the genesis time of the network and the round number). The corresponding Prometheus metric is the gauge `client_http_heartbeat_latency`. In normal conditions, when the network latency is sub-second, one expects the heartbeat latency to be roughly evenly distributed between 0 and 30 seconds. This is caused by the fact that there are multiple heartbeats during a single round, which lasts 30 seconds, as well as the fact that each request blocks until the randomness becomes available. This metric is implemented in [https://github.com/drand/drand/blob/master/client/http/metric.go#L59].
 
 - _Heartbeat success and failure_: These are two counters, "success" and "failure", whose Prometheus names are `client_http_heartbeat_success` and `client_http_heartbeat_latency`. The success counter is increments after an HTTP request returns a successful response HTTP, otherwise the the failure counter is incremented. This metric is implemented in [https://github.com/drand/drand/blob/master/client/http/metric.go#L50].
 

--- a/docs/operate/metrics.md
+++ b/docs/operate/metrics.md
@@ -1,5 +1,5 @@
 ---
-title: Drand Metrics
+title: Drand metrics
 ---
 
 # Drand Metrics

--- a/docs/operate/organization.md
+++ b/docs/operate/organization.md
@@ -2,7 +2,7 @@
 title: Organization
 ---
 
-# Drand Code Organization
+# Code organization
 
 ## Top level packages
 

--- a/docs/quickstart/README.md
+++ b/docs/quickstart/README.md
@@ -1,9 +1,9 @@
 ---
 title: Quickstart
-description: Get up and running with Drand quickly! Learn how to grab randomness and integrate it into a simple project.
+description: Get up and running with drand quickly! Learn how to grab randomness and integrate it into a simple project.
 ---
 
-<!-- This page helps readers understand the basic of the Drand project quickly. Hopefully we can do this by creating an interactive demo that readers to use to jump-start their learning. -->
+<!-- This page helps readers understand the basic of the drand project quickly. Hopefully we can do this by creating an interactive demo that readers to use to jump-start their learning. -->
 
 # Quickstart
 


### PR DESCRIPTION
Changes `Drand` to `drand` when not at the start of a sentence. Also uses sentence styling for headers and menu items: `This is a header`, not `This is a Header`.