### PR TITLE
feat: add a simple footer to the homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you want to build this site locally, run the following:
    git clone https://github.com/drand/website.git
    ```
 
-1. Move into the `website` folder and install the NPM dependencies:
+1. Move into the `website` folder and install the npm dependencies:
 
    ```bash
    cd website

--- a/docs/.vuepress/theme/components/Home.vue
+++ b/docs/.vuepress/theme/components/Home.vue
@@ -43,9 +43,7 @@
 
     <Content class="theme-default-content custom" />
 
-    <div v-if="data.footer" class="footer">
-      {{ data.footer }}
-    </div>
+    <Content class="footer" slot-key="footer" />
   </main>
 </template>
 
@@ -76,6 +74,11 @@ export default {
 <style lang="stylus">
 .home
   display block
+  h2
+    font-size 2rem
+    border-bottom none
+    padding-bottom 0
+    font-style italic
   .hero
     background #0B1232
     padding 3rem
@@ -104,11 +107,6 @@ export default {
     padding 0 1.2rem
   .feature
     margin 3rem auto
-    h2
-      font-size 2rem
-      border-bottom none
-      padding-bottom 0
-      font-style italic
     p
       margin 2rem auto
     .action-button
@@ -131,7 +129,7 @@ export default {
         background-color lighten($accentColor, 10%)
   .theme-default-content
     max-width $homePageWidth
-    margin 0px auto
+    margin 3rem auto
     padding 0 2rem
   .footer
     max-width $homePageWidth
@@ -140,6 +138,8 @@ export default {
     border-top 1px solid $borderColor
     text-align center
     color lighten($textColor, 25%)
+    p:first-child
+      margin-top 0
 
 @media (min-width: $MQNarrow)
   .home

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,3 +30,7 @@ Billions of devices around the world use random numbers to keep computers secure
 Help the internet by generating truely random numbers with drand. [Manage a node →](/operator)
 
 The drand project is maintained by contributors from many different fields, companies, and research labs. If you'd like to contribute code, submit issues, improve documentation, or get the word out, [find out how to get involved with the project →](/about)
+
+::: slot footer
+Apache 2.0 or MIT Licensed · [Status](https://drand.statuspage.io/) · [GitHub](https://github.com/drand/drand) · Made with ❤️
+:::


### PR DESCRIPTION
<img width="1273" alt="Screenshot 2020-07-02 at 11 31 35" src="https://user-images.githubusercontent.com/152863/86348575-c1557000-bc57-11ea-8163-b9fd201d0f50.png">

(also tweaks the headers for the content to be consistent with other headers on the page)

resolves https://github.com/drand/website/issues/45