### PR TITLE
feat: switch to mainnet

### DIFF
--- a/docs/.vuepress/theme/components/LoE.vue
+++ b/docs/.vuepress/theme/components/LoE.vue
@@ -62,12 +62,13 @@
 import NavLink from '@theme/components/NavLink.vue'
 import Client, { HTTP } from 'drand-client'
 
-const TESTNET_CHAIN_HASH =
-  '84b2234fb34e835dccd048255d7ad3194b81af7d978c3bf157e3469592ae4e02'
-const TESTNET_URLS = [
-  'https://pl-eu.testnet.drand.sh',
-  'https://pl-us.testnet.drand.sh',
-  'https://pl-sin.testnet.drand.sh'
+const CHAIN_HASH =
+  '8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce'
+const URLS = [
+  'https://api.drand.sh',
+  'https://api2.drand.sh',
+  'https://api3.drand.sh',
+  'https://drand.cloudflare.com'
 ]
 
 const chars = '0123456789abcdef'
@@ -81,10 +82,9 @@ export default {
 
   async mounted() {
     try {
-      const client = await Client.wrap(
-        HTTP.forURLs(TESTNET_URLS, TESTNET_CHAIN_HASH),
-        { chainHash: TESTNET_CHAIN_HASH }
-      )
+      const client = await Client.wrap(HTTP.forURLs(URLS, CHAIN_HASH), {
+        chainHash: CHAIN_HASH
+      })
 
       const info = await client.info()
 

--- a/docs/developer/clients.md
+++ b/docs/developer/clients.md
@@ -29,24 +29,24 @@ The drand client library is structured with a base client interface in `/client`
 package main
 
 import (
-    "context"
-    "encoding/hex"
-    "fmt"
-    "github.com/drand/drand/client"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"github.com/drand/drand/client"
 )
 
-var chainHash, _ = hex.DecodeString("TODO-LOE-CHAIN-HASH")
+var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
 
 func main() {
-    c, err := client.New(
-        client.From(/* add concrete client implementations here (see below) */),
-        client.WithChainHash(chainHash),
-    )
+	c, err := client.New(
+		client.From(/* add concrete client implementations here (see below) */),
+		client.WithChainHash(chainHash),
+	)
 
-    // e.g. use the client to get the latest randomness round:
-    r := c.Get(context.Background(), 0)
+	// e.g. use the client to get the latest randomness round:
+	r := c.Get(context.Background(), 0)
 
-    fmt.Println(r.Round(), r.Randomness())
+	fmt.Println(r.Round(), r.Randomness())
 }
 ```
 
@@ -73,22 +73,26 @@ The HTTP client uses the [JSON HTTP API](/developer/http-api/) to fetch randomne
 package main
 
 import (
-    "context"
-    "encoding/hex"
-    "fmt"
-    "github.com/drand/drand/client"
-    "github.com/drand/drand/client/http"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"github.com/drand/drand/client"
+	"github.com/drand/drand/client/http"
 )
 
-const url = "https://drand.cloudflare.com"
+var urls = []string{
+	"https://api.drand.sh",
+	"https://drand.cloudflare.com",
+	// ...
+}
 
-var chainHash, _ = hex.DecodeString("TODO-LOE-CHAIN-HASH")
+var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
 
 func main() {
-    c, err := client.New(
-        client.From(http.ForURLs([]string{url}, chainHash)...),
-        client.WithChainHash(chainHash),
-    )
+	c, err := client.New(
+		client.From(http.ForURLs(urls, chainHash)...),
+		client.WithChainHash(chainHash),
+	)
 }
 ```
 
@@ -108,27 +112,27 @@ The [gRPC](https://grpc.io/) client connects to a drand gRPC endpoint to fetch r
 package main
 
 import (
-    "context"
-    "encoding/hex"
-    "fmt"
-    "github.com/drand/drand/client"
-    "github.com/drand/drand/client/grpc"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"github.com/drand/drand/client"
+	"github.com/drand/drand/client/grpc"
 )
 
 const (
-    grpcAddr  = "example.drand.grpc.server:4444"
-    certPath  = "/path/to/drand-grpc.cert"
+	grpcAddr  = "example.drand.grpc.server:4444"
+	certPath  = "/path/to/drand-grpc.cert"
 )
 
-var chainHash, _ = hex.DecodeString("TODO-LOE-CHAIN-HASH")
+var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
 
 func main() {
-    gc, err := grpc.New(grpcAddr, certPath, false)
+	gc, err := grpc.New(grpcAddr, certPath, false)
 
-    c, err := client.New(
-        client.From(gc),
-        client.WithChainHash(chainHash),
-    )
+	c, err := client.New(
+		client.From(gc),
+		client.WithChainHash(chainHash),
+	)
 }
 ```
 
@@ -148,7 +152,9 @@ If you need to `Get` arbitrary rounds from the chain then you must combine this 
 
 Drand _does not_ publish randomness rounds over libp2p PubSub by default but provides a [relay tool](/operator/drand-cli/#drand-relay-gossip) that performs this task. The [League of Entropy](https://blog.cloudflare.com/league-of-entropy/) provide the following public drand libp2p PubSub relays:
 
-- `/dns4/todo/p2p/QmPeerID`
+- `/dnsaddr/api.drand.sh`
+- `/dnsaddr/api2.drand.sh`
+- `/dnsaddr/api3.drand.sh`
 
 :::tip
 Connect your libp2p host to one or more of these relays to ensure you continue to receive randomness rounds.
@@ -163,29 +169,29 @@ package main
 
 import (
 	"context"
-    "fmt"
-    "github.com/drand/drand/chain"
+	"fmt"
+	"github.com/drand/drand/chain"
 	"github.com/drand/drand/client"
-    gclient "github.com/drand/drand/lp2p/client"
-    pubsub "github.com/libp2p/go-libp2p-pubsub"
+	gclient "github.com/drand/drand/lp2p/client"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
 func main() {
-    ps := newPubSub()
+	ps := newPubSub()
 	info := readChainInfo()
 
 	c, err := client.New(
-        gclient.WithPubsub(ps),
-        client.WithChainInfo(info),
-    )
+		gclient.WithPubsub(ps),
+		client.WithChainInfo(info),
+	)
 }
 
 func newPubSub() *pubsub.Pubsub {
-    /* ... */
+	/* ... */
 }
 
 func readChainInfo() *chain.Info {
-    /* ... */
+	/* ... */
 }
 ```
 
@@ -196,29 +202,33 @@ package main
 
 import (
 	"context"
-    "fmt"
-    "github.com/drand/drand/chain"
+	"fmt"
+	"github.com/drand/drand/chain"
 	"github.com/drand/drand/client"
-    gclient "github.com/drand/drand/lp2p/client"
-    pubsub "github.com/libp2p/go-libp2p-pubsub"
+	gclient "github.com/drand/drand/lp2p/client"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 )
 
-const url = "https://drand.cloudflare.com"
+var urls = []string{
+	"https://api.drand.sh",
+	"https://drand.cloudflare.com",
+	// ...
+}
 
-var chainHash, _ = hex.DecodeString("TODO-LOE-CHAIN-HASH")
+var chainHash, _ = hex.DecodeString("8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce")
 
 func main() {
-    ps := newPubSub()
+	ps := newPubSub()
 
 	c, err := client.New(
-        gclient.WithPubsub(ps),
-        client.WithChainHash(chainHash),
-        client.From(http.ForURLs([]string{url}, chainHash)...),
-    )
+		gclient.WithPubsub(ps),
+		client.WithChainHash(chainHash),
+		client.From(http.ForURLs(urls, chainHash)...),
+	)
 }
 
 func newPubSub() *pubsub.Pubsub {
-    /* ... */
+	/* ... */
 }
 ```
 
@@ -242,17 +252,19 @@ npm install drand-client
 
 ```html
 <script type="module">
-  import Client, {
-    HTTP
-  } from 'https://cdn.jsdelivr.net/npm/drand-client/drand.js'
+  import Client, { HTTP } from 'https://cdn.jsdelivr.net/npm/drand-client/drand.js'
 
-  const chainHash = 'TODO-LOE-CHAIN-HASH' // (hex encoded)
-  const url = 'https://drand.cloudflare.com'
+  const chainHash = '8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce' // (hex encoded)
+  const urls = [
+    'https://api.drand.sh',
+    'https://drand.cloudflare.com'
+    // ...
+  ]
 
   async function main() {
     const options = { chainHash }
 
-    const client = await Client.wrap(HTTP.forURLs([url], chainHash), options)
+    const client = await Client.wrap(HTTP.forURLs(urls, chainHash), options)
 
     // e.g. use the client to get the latest randomness round:
     const res = await client.get()

--- a/docs/developer/http-api.md
+++ b/docs/developer/http-api.md
@@ -6,13 +6,18 @@ All that's required is the address of the HTTP interface and way to fetch from H
 
 The public [League of Entropy](https://blog.cloudflare.com/league-of-entropy/) HTTP APIs are available at:
 
-- [https://drand.cloudflare.com](https://drand.cloudflare.com)
-- [https://drand.protocol.ai:8081](https://drand.protocol.ai:8081)
-- [https://ln.soc1024.com:8888](https://ln.soc1024.com:8888)
-- [https://drand.nikkolasg.xyz:4444](https://drand.nikkolasg.xyz:4444)
-- [https://drand2.kudelskisecurity.com](https://drand2.kudelskisecurity.com)
+- Protocol Labs
+    - [https://api.drand.sh](https://api.drand.sh)
+    - [https://api2.drand.sh](https://api2.drand.sh)
+    - [https://api3.drand.sh](https://api3.drand.sh)
+- Cloudflare
+    - [https://drand.cloudflare.com](https://drand.cloudflare.com)
 
-The chain hash for the League of Entropy drand group is `TODO-LOE-CHAIN-HASH`
+The chain hash for the League of Entropy drand group is:
+
+```
+8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce
+```
 
 ## `/info`
 
@@ -20,10 +25,10 @@ Retrieves the randomness chain information. It returns a JSON object with the fo
 
 ```json
 {
-  "public_key": "aaddd53d2c92454b698c52495990162bc999778a32fd570dad2ef3de2915a5b397d80ec5508919e84cd10944955b7318",
-  "period": 10,
-  "genesis_time": 1592226590,
-  "hash": "c599c267a0dd386606f7d6132da8327d57e1004760897c9dd4fb8495c29942b2"
+  "public_key": "868f005eb8e6e4ca0a47c8a77ceaa5309a47978a7c71bc5cce96366b5d7a569937c529eeda66c7293784a9402801af31",
+  "period": 30,
+  "genesis_time": 1595431050,
+  "hash": "8990e7a9aaed2ffed73dbd7092123d6f289930540d7651336225dc172e51b2ce"
 }
 ```
 
@@ -39,16 +44,16 @@ Retrives the latest round of randomness. It returns a JSON object with the follo
 ```json
 {
   "round": 367,
-  "signature": "b62dd642e939191af1f9e15bef0f0b0e9562a5f570a12a231864afe468377e2a6424a92ccfc34ef1471cbd58c37c6b020cf75ce9446d2aa1252a090250b2b1441f8a2a0d22208dcc09332eaa0143c4a508be13de63978dbed273e3b9813130d5",
-  "previous_signature": "afc545efb57f591dbdf833c339b3369f569566a93e49578db46b6586299422483b7a2d595814046e2847494b401650a0050981e716e531b6f4b620909c2bf1476fd82cf788a110becbc77e55746a7cccd47fb171e8ae2eea2a22fcc6a512486d",
-  "randomness": "d7aed3686bf2be657e6d38c20999831308ee6244b68c8825676db580e7e3bec6"
+  "randomness": "3439d92d58e47d342131d446a3abe264396dd264717897af30525c98408c834f",
+  "signature": "90957ebc0719f8bfb67640aff8ca219bf9f2c5240e60a8711c968d93370d38f87b38ed234a8c63863eb81f234efce55b047478848c0de025527b3d3476dfe860632c1b799550de50a6b9540463e9fb66c8016b89c04a9f52dabdc988e69463c1",
+  "previous_signature": "859504eade86790ad09b2b3474d5e09d1718b549ef7107d7bbd18f5e221765ce8252d7db02664c1f6b20f40c6e8e138704d2acfeb6c5abcc14c77e3a842b2f84515e7366248ca37b1460d23b4f98493c246fbb02851f2a43a710c968a349f8d6"
 }
 ```
 
 - `round` is an sequentially increasing integer - the randomness round index
+- `randomness` is a SHA-512 hash of the signature
 - `signature` is the _Boneh-Lynn-Shacham_ (BLS) signature for this round of randomness
 - `previous_signature` is the signature of the previous round of randomness
-- `randomness` is a SHA-512 hash of the signature
 
 ## `/public/{round}`
 
@@ -57,13 +62,13 @@ Retrieves a previous round of randomness identified by the positive integer `rou
 ```json
 {
   "round": 367,
-  "signature": "b62dd642e939191af1f9e15bef0f0b0e9562a5f570a12a231864afe468377e2a6424a92ccfc34ef1471cbd58c37c6b020cf75ce9446d2aa1252a090250b2b1441f8a2a0d22208dcc09332eaa0143c4a508be13de63978dbed273e3b9813130d5",
-  "previous_signature": "afc545efb57f591dbdf833c339b3369f569566a93e49578db46b6586299422483b7a2d595814046e2847494b401650a0050981e716e531b6f4b620909c2bf1476fd82cf788a110becbc77e55746a7cccd47fb171e8ae2eea2a22fcc6a512486d",
-  "randomness": "d7aed3686bf2be657e6d38c20999831308ee6244b68c8825676db580e7e3bec6"
+  "randomness": "3439d92d58e47d342131d446a3abe264396dd264717897af30525c98408c834f",
+  "signature": "90957ebc0719f8bfb67640aff8ca219bf9f2c5240e60a8711c968d93370d38f87b38ed234a8c63863eb81f234efce55b047478848c0de025527b3d3476dfe860632c1b799550de50a6b9540463e9fb66c8016b89c04a9f52dabdc988e69463c1",
+  "previous_signature": "859504eade86790ad09b2b3474d5e09d1718b549ef7107d7bbd18f5e221765ce8252d7db02664c1f6b20f40c6e8e138704d2acfeb6c5abcc14c77e3a842b2f84515e7366248ca37b1460d23b4f98493c246fbb02851f2a43a710c968a349f8d6"
 }
 ```
 
 - `round` is an sequentially increasing integer - the randomness round index
+- `randomness` is a SHA-512 hash of the signature
 - `signature` is the _Boneh-Lynn-Shacham_ (BLS) signature for this round of randomness
 - `previous_signature` is the signature of the previous round of randomness
-- `randomness` is a SHA-512 hash of the signature


### PR DESCRIPTION
* Homepage LoE section now uses mainnet
* Mainnet chain hash, HTTP API URLs and pubsub relay addrs added to docs
* HTTP API Endpoint examples switched to using mainnet data
* Go and JS code examples fixed to use tabs and spaces respectively (for nice copy paste experience)

resolves https://github.com/drand/website/issues/52