### PR TITLE
feat: move code of conduct

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -71,6 +71,7 @@ module.exports = {
           '/developer/': ['clients', 'http-api', 'gossipsub', 'drand-client'],
           '/operator/': ['deploy', 'docker', 'metrics', 'drand-cli'],
           '/about/': [
+            'code-of-conduct',
             'community',
             'contributing',
             {

--- a/docs/about/code-of-conduct.md
+++ b/docs/about/code-of-conduct.md
@@ -1,0 +1,71 @@
+# Code of Conduct
+
+We believe that our mission is best served in an environment that is friendly, safe, and accepting, and free from intimidation or harassment. Towards this end, certain behaviors and practices will not be tolerated.
+
+## tl;dr
+
+- Be respectful.
+- We're here to help: [abuse@ipfs.io](mailto:abuse@ipfs.io)
+- Abusive behavior is never tolerated.
+- Violations of this code may result in swift and permanent expulsion from the community.
+- "Too long, didn't read" is not a valid excuse for not knowing what is in this document.
+
+## Scope
+
+We expect all members of the community to abide by this Code of Conduct at all times in all community venues, online and in person, and in one-on-one communications pertaining to the project.
+
+This policy covers the usage of our public infrastructure, including the drand network, as well as drand related events, and any other services offered by or on behalf of the drand community. It also
+applies to behavior in the context of the Open Source project community, including but not limited to public GitHub repositories, IRC channels, social media, mailing lists, and public events.
+
+The definitions of various subjective terms such as "discriminatory", "hateful", or "confusing" will be decided at the sole discretion of the [abuse team](#contact-info).
+
+## Friendly Harassment-Free Space
+
+We are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity, sexual orientation, disability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics.
+
+We ask that you please respect that people have differences of opinion regarding technical choices, and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a single right answer. A difference of technology preferences is not a license to be rude.
+
+Any spamming, trolling, flaming, baiting, or other attention-stealing behavior is not welcome, and will not be tolerated.
+
+Harassing other users is never tolerated, whether via public or private media.
+
+Avoid using offensive or harassing nicknames, or other identifiers that might detract from a friendly, safe, and welcoming environment for all.
+
+Harassment includes, but is not limited to: any behavior that threatens or demeans another person or group, or produces an unsafe environment; harmful or prejudicial verbal or written comments related to gender, gender expression, gender identity, sexual orientation, disability, ethnicity, religion, age, physical appearance, body size, race, or similar personal characteristics; inappropriate use of nudity, sexual images, and/or sexually explicit language in public spaces; threats of physical or non-physical harm; deliberate intimidation, stalking or following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; and unwelcome sexual attention.
+
+## Reporting Violations of this Code of Conduct
+
+If you believe someone is harassing you or has otherwise violated this Code of Conduct, please [contact us](#contact-info) to send us an abuse report. If this is the initial report of a problem, please include as much detail as possible. It is easiest for us to address issues when we have more context.
+
+## Consequences
+
+Unacceptable behavior from any community member will not be tolerated.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately.
+
+If a community member engages in unacceptable behavior, the team may take any action they deem appropriate, up to and including a temporary ban or permanent expulsion from the community without warning (and without refund in the case of a paid event or service).
+
+## Addressing Grievances
+
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify the team. We will do our best to ensure that your grievance is handled appropriately.
+
+In general, we will choose the course of action that we judge as being most in the interest of fostering a safe and friendly community.
+
+On IRC, let one of the ops know if you think that someone has transgressed against the Code of Conduct. If you would like to be an op and promise to help maintain and abide by the code, please let us know.
+
+## Contact Info
+
+As the drand community itself remains small, we have asked the [IPFS abuse team](https://github.com/ipfs/community/blob/master/code-of-conduct.md#contact-info) to act as a neutral arbiter and point of contact for Code of Conduct and abuse issues within drand.
+
+You are also encouraged to contact us if you are curious about something that might be "on the line" between appropriate and inappropriate content. We are happy to provide guidance to help you be a successful part of our community.
+
+## Changes
+
+This is a living document and may be updated from time to time. Please refer to the git history for this document to view the changes.
+
+## Credit and License
+
+This Code of Conduct is based on the [IPFS Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md) itself based on the [npm Code of Conduct](https://www.npmjs.com/policies/conduct), [CodeOfConduct4Lib](https://github.com/code4lib/code-of-conduct/blob/master/code_of_conduct.md), and the [example policy](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment) from the [Geek Feminism wiki](http://geekfeminism.wikia.com/), created by the Ada Initiative and other volunteers.
+
+This document may be reused under a [Creative Commons Attribution-ShareAlike
+License](http://creativecommons.org/licenses/by-sa/4.0/).


### PR DESCRIPTION
The PR moves the code of conduct from the drand repo so it can be publicised and referenced from a central location.

I removed the "Table of Contents" because it's in the sidebar.

<img width="1291" alt="Screenshot 2020-08-10 at 09 09 55" src="https://user-images.githubusercontent.com/152863/89763144-d55b7f80-dae9-11ea-8d6e-9e1fe40ef49f.png">
