### PR TITLE
Removes old GA ID.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -109,7 +109,7 @@ module.exports = {
     [
       '@vuepress/google-analytics',
       {
-        ga: 'UA-96910779-15'
+        ga: ''
       }
     ],
     [


### PR DESCRIPTION
Leaving the field blank for now, may want to fill it in in the near future.