### PR TITLE
Adds mailing list link.

### DIFF
--- a/docs/about/community.md
+++ b/docs/about/community.md
@@ -13,4 +13,4 @@ For now, the best way to join in with the community is [through GitHub](https://
 
 ## Mailing list
 
-We now have an announcement mailing list for all Leauge of Entropy users. This mailing list is meant to announce any changes impacting Drand users downstream and is written and maintained by a League of Entropy secretariat. You can join the mailing list by visiting [`groups.google.com/g/leagueofentropy-users`](https://groups.google.com/g/leagueofentropy-users).
+We now have an announcement mailing list for all Leauge of Entropy users. This mailing list is meant to announce any changes impacting Drand users downstream and is written and maintained by a League of Entropy secretariat. You can join the mailing list by visiting [groups.google.com/g/leagueofentropy-users](https://groups.google.com/g/leagueofentropy-users).

--- a/docs/about/community.md
+++ b/docs/about/community.md
@@ -5,4 +5,12 @@ description: Join in with the drand community!
 
 # Community
 
-The drand project is still in it's early stages, and we're building ways to interact with the community as we continue to build everything. For now, the best way to join in with the community is [through GitHub](https://github.com/drand). In the next few weeks we'll open up a forum and IRC channel for public discussion.
+The drand project is still in it's early stages, and we're building ways to interact with the community as we continue to build everything. In the next few weeks we'll open up a forum and IRC channel for public discussion.
+
+## GitHub
+
+For now, the best way to join in with the community is [through GitHub](https://github.com/drand).
+
+## Mailing list
+
+We now have an announcement mailing list for all Leauge of Entropy users. This mailing list is meant to announce any changes impacting Drand users downstream and is written and maintained by a League of Entropy secretariat. You can join the mailing list by visiting [`groups.google.com/g/leagueofentropy-users`](https://groups.google.com/g/leagueofentropy-users).


### PR DESCRIPTION
Closes #81. Simply adds a paragraph describing the LoE mailing list in `/about/community/`.