### PR TITLE
Fixes wrong date bug in VuePress.

### DIFF
--- a/docs/blog/2021-08-10-drand-celebrates-one-year-as-a-randomness-service.md
+++ b/docs/blog/2021-08-10-drand-celebrates-one-year-as-a-randomness-service.md
@@ -1,7 +1,6 @@
 ---
 title: Drand celebrates one year as a randomness service!
 summary:  It's been a while year since Drand first launched it's mainnet distributed randomness beacon service.
-date: 2021-08-10
 tags: 
     - Jobs
     - Anniversary


### PR DESCRIPTION
So if you add a `date` field to a blog's metadata, VuePress gets confused and tries to display _yesterdays_ date instead. Removing the data field from a posts metadata forces VuePress to use the blogposts title to discover the date.