### PR TITLE
Removes algolia for now. Uses default search.

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -24,11 +24,9 @@ module.exports = {
     }
   },
   themeConfig: {
-    algolia: {
-      apiKey: 'fcaf3b4aca77fcfeff32616ec6e35a86',
-      indexName: 'drand'
-    },
     defaultImage: '/images/social-card.png',
+    search: true,
+    searchMaxSuggestions: 10,
     author: {
       name: 'Drand Team',
       twitter: ''


### PR DESCRIPTION
The search bar doesn't work right now because the Algolia Docsearch account is linked to `beta.drand.love`, instead of just `drand.love`. We need to re-apply to the open-source Docsearch program to have Algolia re-index the site and get everything working again.

For now, I'm rolled back to the default VuePress search. It only looks for H1, H2, and H3 titles, and doesn't delve into the content of each page. But it'll do for now.

Mostly closes #101.