### PR TITLE
Contact email on front page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ The drand project is maintained by contributors from many different fields, comp
 
 ## Get in touch
 
-For questions, comments, or to start a collaboration, please reach the drand team at: leagueofentropy@googlegroups.com to get the discussion going.
+For questions, comments, or to start a collaboration, please reach the drand team at: leagueofentropy [ at ] googlegroups.com to get the discussion going.
 
 
 ::: slot footer

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,11 @@ Billions of devices around the world use random numbers to keep computers secure
 
 The drand project is maintained by contributors from many different fields, companies, and research labs. If you'd like to contribute code, submit issues, improve documentation, or get the word out, [find out how to get involved with the project →](/partner-with-us/)
 
+## Get in touch
+
+For questions, comments, or to start a collaboration, please reach the drand team at: leagueofentropy@googlegroups.com to get the discussion going.
+
+
 ::: slot footer
 Apache 2.0 or MIT Licensed · [Status](https://drand.statuspage.io/) · [GitHub](https://github.com/drand/drand) · Made with ❤️
 :::


### PR DESCRIPTION
The contact email of the drand team has so far been hidden at the bottom of the "About" page: https://drand.love/about/. That's not good and we've already heard that a team has tried to reach us and had to rely on contacts of contacts to get through.

This PR is adding the LoE email at the bottom of the landing page. In the future, we can add a separate "Contact" tab at the top of the page, but for a single email it doesn't make sense.