### PR TITLE
Update hiring link

### DIFF
--- a/docs/.vuepress/nav/en.js
+++ b/docs/.vuepress/nav/en.js
@@ -12,6 +12,6 @@ module.exports = [
   { text: 'Blog', link: '/blog/' },
   {
     text: "We're hiring",
-    link: 'https://jobs.lever.co/protocol/ca0b97f4-6117-4004-8d7d-1a4520e2d5be'
+    link: 'https://boards.greenhouse.io/protocollabs/jobs/4283635004'
   }
 ]

--- a/docs/partner-with-us/README.md
+++ b/docs/partner-with-us/README.md
@@ -34,7 +34,7 @@ getStartedLink: https://docs.google.com/forms/d/e/1FAIpQLScaFa4UTTh7BQsAzz0bLDZ5
 
 ### Get started now
 
-Fill in the [Form](https://docs.google.com/forms/d/e/1FAIpQLScaFa4UTTh7BQsAzz0bLDZ5t3U8IO8dusy0dOK4iYYim6yLhA/viewform?usp=sf_link) to express your interest in joining the League of Entropy and one of our member organizations will get in touch shortly.
+Fill in the [Form](https://docs.google.com/forms/d/e/1FAIpQLScaFa4UTTh7BQsAzz0bLDZ5t3U8IO8dusy0dOK4iYYim6yLhA/viewform?usp=sf_link), or send us an email (leagueofentropy [ at ] googlegroups.com) to express your interest in joining the League of Entropy and one of our member organizations will get in touch shortly.
 
 
 ::: slot footer


### PR DESCRIPTION
The move to greenhouse broke the previous link to Lever. Updating to the latest one: https://boards.greenhouse.io/protocollabs/jobs/4283635004