### PR TITLE
Missing Blogpost Tags

### DIFF
--- a/docs/blog/2021-09-14-the-value-of-drand.md
+++ b/docs/blog/2021-09-14-the-value-of-drand.md
@@ -2,6 +2,8 @@
 title: The value of drand
 summary: "We asked the League of Entropy members: “what’s the value of drand for you, and why do you support it?” Check out what they said!"
 date: 2021-09-14
+tags:
+    - League of Entropy
 ---
 _"We asked the League of Entropy members: “what’s the value of drand for you, and why do you support it?” Check out what they said!"_
  

--- a/docs/blog/2021-10-28-the-value-of-drand-continued.md
+++ b/docs/blog/2021-10-28-the-value-of-drand-continued.md
@@ -2,6 +2,8 @@
 title: "The value of drand _(continued)_"
 summary: "This blog post covers the second set of responses we received from League of Entropy members on our question: What’s the value of drand for your organisation and why do you support it!"
 date: 2021-10-28
+tags:
+    - League of Entropy
 ---
 
 This blog post covers the second set of responses we received from League of Entropy members on our question: _“What’s the value of drand for your organisation and why do you support it”_! We hope you enjoyed [the first part](../blog/2021-09-14-the-value-of-drand.md) as much as we did. Read on to get more inspiration and come join as an operator, or a [Software Engineer](https://jobs.lever.co/protocol/ca0b97f4-6117-4004-8d7d-1a4520e2d5be) to take drand to the next level, and establish it as a foundational Internet protocol!

--- a/docs/blog/2022-02-21-multi-frequency-support-and-timelock-encryption-capabilities.md
+++ b/docs/blog/2022-02-21-multi-frequency-support-and-timelock-encryption-capabilities.md
@@ -2,6 +2,8 @@
 title: "Multi Frequency Support and Timelock Encryption Capabilities are coming in drand!"
 summary: "The drand team has been hard at work the last couple of months to develop and integrate new and extremely valuable features into the drand codebase: timelock encryption, and multi-frequency support!"
 date: 2022-02-21
+tags:
+    - Features
 ---
 
 The drand team has been hard at work the last couple of months to develop and integrate new and extremely valuable features into the drand codebase! We have worked together with [Zondax](https://zondax.ch/), a research and software development company, and we are extremely excited to announce the completion of a very important project for the future of drand. The project focused on two important features that have the potential to unlock new capabilities for the drand randomness service, enable new application scenarios and make drand able to support many more applications and platforms.

--- a/docs/blog/2022-03-28-storswift-joining.md
+++ b/docs/blog/2022-03-28-storswift-joining.md
@@ -2,6 +2,10 @@
 title: "StorSwift joins the League of Entropy"
 summary: "StorSwift becomes the newest member of the League of Entropy. We've asked them why they're motivated by drand and decided to contribute - check what they said!"
 date: 2022-03-30
+tags:
+    - New members
+    - League of Entropy
+    - News
 ---
 
 _"StorSwift becomes the newest member of the League of Entropy. We've asked them why they're motivated by drand and decided to contribute - check what they said!"_

--- a/docs/blog/2022-06-24-drand-at-northsec.md
+++ b/docs/blog/2022-06-24-drand-at-northsec.md
@@ -2,6 +2,9 @@
 title: "drand @ NorthSec"
 summary: "Drand was recently presented at the North Sec conference! Here is a brief summary of the event and the drand talk, as well as the answers to a few of the interesting questions we received."
 date: 2022-06-24
+tags:
+    - Conferences and Events
+    - News
 ---
 
 _Drand was recently presented at the North Sec conference! Here is a brief summary of the event and the drand talk, as well as the answers to a few of the interesting questions we received._


### PR DESCRIPTION
I've realised we've missed adding tags to several of the recent blogposts, so this PR is adding them. We'll probably need a cleanup of tags too at some point, as some of them overlap, e.g., "News" and "Updates" - not sure what's the difference between the two :)