### PR TITLE
Adds author var to post and postlist page.

### DIFF
--- a/docs/.vuepress/theme/components/PostList.vue
+++ b/docs/.vuepress/theme/components/PostList.vue
@@ -27,6 +27,9 @@
             >{{ tag }}</router-link
           >
         </span>
+        <span v-if="page.frontmatter.author" class="meta">
+          Author: {{ page.frontmatter.author }}
+        </span>
       </footer>
     </article>
   </div>

--- a/docs/.vuepress/theme/layouts/Post.vue
+++ b/docs/.vuepress/theme/layouts/Post.vue
@@ -10,6 +10,9 @@
               {{ resolvePostDate($page.frontmatter.date) }}
             </time>
           </span>
+          <span v-if="$page.frontmatter.author" class="meta">
+            Author: {{ $page.frontmatter.author }}
+          </span>
           <span v-if="$page.frontmatter.tags" class="meta tags">
             <img src="/images/icon-tag.svg" />
             <router-link


### PR DESCRIPTION
This PR allows writers to add their name to a post by using the `author` variable in the blog post front-matter. This PR **does not** change any of the blog posts though - no author variables have been added to posts yet.

```markdown
---
title: "drand @ NorthSec"
summary: "Drand was recently presented at the North Sec conference! Here is a brief summary of the event and the drand talk, as well as the answers to a few of the interesting questions we received."
date: 2022-06-24
author: "Johnny"
---

_Drand was recently presented at the North Sec conference! Here is a brief summary of the event and the drand talk, as well as the answers to a few of the interesting questions we received._
```

![image](https://user-images.githubusercontent.com/9611008/184660020-8d86a1bd-e342-43ad-97ef-5af94e270d36.png)

![image](https://user-images.githubusercontent.com/9611008/184660125-dedfb757-ad41-4456-a87c-470c0bdacd5c.png)