### PR TITLE
Update invalid public endpoints for protocol labs

### DIFF
--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -8,9 +8,9 @@ This section helps developers build applications that use drand as a source of r
 
 The current public League of Entropy drand mainnet API endpoints are:
 
-* `https://api.drand.sh` (HTTPS endpoint, also available over HTTP)
-* `https://api2.drand.sh` (HTTPS endpoint, also available over HTTP)
-* `https://api3.drand.sh` (HTTPS endpoint, also available over HTTP)
+* `https://api.drand.sh/v2` (HTTPS endpoint, also available over HTTP)
+* `https://api2.drand.sh/v2` (HTTPS endpoint, also available over HTTP)
+* `https://api3.drand.sh/v2` (HTTPS endpoint, also available over HTTP)
 * `https://drand.cloudflare.com` (HTTPS endpoint)
 * `https://api.drand.secureweb3.com:6875` (HTTPS endpoint)
 * `/dnsaddr/api.drand.sh` (1st-level libp2p gossipsub relay endpoint)

--- a/docs/developer/http-api.md
+++ b/docs/developer/http-api.md
@@ -9,9 +9,9 @@ All that's required is the address of the HTTP interface and way to fetch from H
 The public [League of Entropy](https://blog.cloudflare.com/league-of-entropy/) HTTP APIs are available at:
 
 - Protocol Labs
-    - [https://api.drand.sh](https://api.drand.sh)
-    - [https://api2.drand.sh](https://api2.drand.sh)
-    - [https://api3.drand.sh](https://api3.drand.sh)
+    - [https://api.drand.sh/v2](https://api.drand.sh/v2)
+    - [https://api2.drand.sh/v2](https://api2.drand.sh/v2)
+    - [https://api3.drand.sh/v2](https://api3.drand.sh/v2)
 - Cloudflare
     - [https://drand.cloudflare.com](https://drand.cloudflare.com)
 - Storswift


### PR DESCRIPTION
The current endpoints will return error message. This patch is to update the endpoints to valid ones.