### PR TITLE
fix: downgrade vuepress-plugin-seo to v0.14

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -127,9 +127,9 @@ module.exports = {
       }
     ],
     [
-      'vuepress-plugin-seo',
+      'seo',
       {
-        siteTitle: ($page, $site) => $site.title,
+        siteTitle: (_, $site) => $site.title,
         title: $page => $page.title,
         description: $page => $page.frontmatter.description,
         author: ($page, $site) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "vuepress-plugin-canonical": "^1.0.0",
         "vuepress-plugin-clean-urls": "^1.1.2",
         "vuepress-plugin-mathjax": "^1.2.8",
-        "vuepress-plugin-seo": "^0.2.0",
+        "vuepress-plugin-seo": "^0.1.4",
         "vuepress-plugin-sitemap": "^2.3.1",
         "vuepress-plugin-sitemap1": "^1.31.0-beta.1"
       }
@@ -19782,9 +19782,9 @@
       }
     },
     "node_modules/vuepress-plugin-seo": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/vuepress-plugin-seo/-/vuepress-plugin-seo-0.2.0.tgz",
-      "integrity": "sha512-/Rqul20UTL30mZyCbNwkfAfP50Yr7jzWlavQ92OVzZ8PcpZGXoDc+eoKQyKLQKL3G96dqvuCCbIMbW7RRs7Bhw==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/vuepress-plugin-seo/-/vuepress-plugin-seo-0.1.4.tgz",
+      "integrity": "sha512-foNKrAAKihiC47bx0UXFzs/+BIFmnowTQsLVF/8pfsnsPDp8FXjkTGyjxyjOhbwj7ADPv32CdX3pEoYGnZ7OjA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "vuepress-plugin-canonical": "^1.0.0",
     "vuepress-plugin-clean-urls": "^1.1.2",
     "vuepress-plugin-mathjax": "^1.2.8",
-    "vuepress-plugin-seo": "^0.2.0",
+    "vuepress-plugin-seo": "^0.1.4",
     "vuepress-plugin-sitemap": "^2.3.1",
     "vuepress-plugin-sitemap1": "^1.31.0-beta.1"
   },


### PR DESCRIPTION
### Summary

This PR downgrades the `vuepress-plugin-seo` package from version 0.2 to 0.14. The upgrade to version 0.2 caused issues with SEO meta generation because version 0.2 is intended for VuePress 2, which is not compatible with our current setup.

### Changes

- Downgraded `vuepress-plugin-seo` to v0.14 in `package.json`.

### References

- https://github.com/lorisleiva/vuepress-plugin-seo/issues/12
